### PR TITLE
Change to SPDX License Identifier (BSD-3-Clause) for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "keywords": ["json", "schema"],
     "homepage": "https://github.com/justinrainbow/json-schema",
     "type": "library",
-    "license": "NewBSD",
+    "license": "BSD-3-Clause",
     "version": "1.1.0",
     "authors": [
         {


### PR DESCRIPTION
The `composer validate` command is now supporting [SPDX license identifers](http://spdx.org/licenses/).

As your package is used within the codebase (and has a composer.json file) I kindly ask to change the license identifier in composer.json from `NewBSD` to `BSD-3-Clause` ([_BSD 3-clause "New" or "Revised" License_](http://spdx.org/licenses/BSD-3-Clause)).

This suggestion has been done in good faith and is not a change of the license, just the way how it is identified. See as well [composer.json license property](http://getcomposer.org/doc/04-schema.md#license).

---

License text: [`LICENSE` file](https://github.com/justinrainbow/json-schema/blob/69af698275e2f25a3f74bd16cf4646849bcf15f8/LICENSE) 69af698275e2f25a3f74bd16cf4646849bcf15f8
Text Reviewed against: http://spdx.org/licenses/BSD-3-Clause ([git vcs](http://git.spdx.org/?p=spdx-tools.git;a=blob;f=resources/stdlicenses/BSD-3-Clause;hb=89de0378951b1109682fefa056cfa1c53ea7d147))
Review: Placeholders are filled in, no other differences than whitespace.
Review result: Match
Review result license identifier: `BSD-3-Clause`
