### PR TITLE
Fix integer check

### DIFF
--- a/src/JsonSchema/Constraints/Type.php
+++ b/src/JsonSchema/Constraints/Type.php
@@ -78,7 +78,7 @@ class Type extends Constraint
         }
 
         if ('integer' === $type) {
-            return (integer) $value == $value ? true : is_int($value);
+            return is_int($value) || ctype_digit($value);
         }
 
         if ('number' === $type) {


### PR DESCRIPTION
If we use "type": "integer", and property is boolean we got an error result (true).
Must be false, because boolean values (true/false) is not a integer.

UPD: Take into account the integer in string.
