### PR TITLE
Missing use statetment added

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/PredefinedArray.php
+++ b/src/JsonSchema/Uri/Retrievers/PredefinedArray.php
@@ -2,6 +2,7 @@
 
 namespace JsonSchema\Uri\Retrievers;
 
+use JsonSchema\Validator;
 use JsonSchema\Uri\Retrievers\UriRetrieverInterface;
 use JsonSchema\Exception\ResourceNotFoundException;
 


### PR DESCRIPTION
I just added a use statement in the PredefinedArray as it is unusable for now 

PHP Fatal error:  Class 'JsonSchema\Uri\Retrievers\Validator' not found in /home/rejinka/projects/api/vendor/justinrainbow/json-schema/src/JsonSchema/Uri/Retrievers/PredefinedArray.php on line 31
