### PR TITLE
Remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "homepage": "https://github.com/justinrainbow/json-schema",
     "type": "library",
     "license": "BSD-3-Clause",
-    "version": "1.2.2",
     "authors": [
         {
             "name": "Bruno Prieto Reis",


### PR DESCRIPTION
Also please re-tag 1.2.2 or tag a 1.2.3 because it's not available on packagist since the version was specified to something different than the tag in the composer.json.
