### PR TITLE
Support for ISO date-time with timezone offset without ":" separator

### DIFF
--- a/src/JsonSchema/Constraints/Format.php
+++ b/src/JsonSchema/Constraints/Format.php
@@ -41,7 +41,8 @@ class Format extends Constraint
 
             case 'date-time':
                 if (!$this->validateDateTime($element, 'Y-m-d\TH:i:s\Z') &&
-                    !$this->validateDateTime($element, 'Y-m-d\TH:i:sP')
+                    !$this->validateDateTime($element, 'Y-m-d\TH:i:sP') &&
+                    !$this->validateDateTime($element, 'Y-m-d\TH:i:sO')
                 ) {
                     $this->addError($path, sprintf('Invalid date time %s, expected format YYYY-MM-DDTHH:MM:SSZ or YYYY-MM-DDTHH:MM:SS+HH:MM', json_encode($element)));
                 }

--- a/tests/JsonSchema/Tests/Constraints/FormatTest.php
+++ b/tests/JsonSchema/Tests/Constraints/FormatTest.php
@@ -73,6 +73,7 @@ class FormatTest extends BaseTestCase
             array('23:59:59', 'time'),
 
             array('2000-05-01T12:12:12Z', 'date-time'),
+			array('2000-05-01T12:12:12+0100', 'date-time'),
             array('2000-05-01T12:12:12+01:00', 'date-time'),
 
             array('0', 'utc-millisec'),
@@ -128,6 +129,7 @@ class FormatTest extends BaseTestCase
             array('25:00:00', 'time'),
 
             array('1999-1-11T00:00:00Z', 'date-time'),
+            array('1999-01-11T00:00:00+100', 'date-time'),
             array('1999-01-11T00:00:00+1:00', 'date-time'),
 
             array('-1', 'utc-millisec'),


### PR DESCRIPTION
also allowed by ISO and used by some JSON libraries
