### PR TITLE
Allow / in patterns

### DIFF
--- a/src/JsonSchema/Constraints/String.php
+++ b/src/JsonSchema/Constraints/String.php
@@ -33,7 +33,7 @@ class String extends Constraint
         }
 
         // Verify a regex pattern
-        if (isset($schema->pattern) && !preg_match('/' . $schema->pattern . '/', $element)) {
+        if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
             $this->addError($path, "does not match the regex pattern " . $schema->pattern);
         }
 


### PR DESCRIPTION
If the pattern in JSON looks like this to match a date, it does not work.

```
pattern: "^\\d{4}/\\d{2}/\\d{2}$"
```

This patch changes the delimiters to #, which have no special meaning as well as occur infrequently, then also changes # in the pattern to #.
