### PR TITLE
Fix patternProperties bugs and do validation on the pattern regex. Add new unit tests.

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/AdditionalPropertiesTest.php
@@ -19,12 +19,16 @@ class AdditionalPropertiesTest extends BaseTestCase
             array(
                 '{
                   "prop":"1",
+                  "patternProp":"3",
                   "additionalProp":"2"
                 }',
                 '{
                   "type":"object",
                   "properties":{
                     "prop":{"type":"string"}
+                  },
+                  "patternProperties":{
+                      "^patternProp$":{"type":"string"}
                   },
                   "additionalProperties": false
                 }',

--- a/tests/JsonSchema/Tests/Constraints/PatternPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/PatternPropertiesTest.php
@@ -37,6 +37,36 @@ class PatternPropertiesTest extends BaseTestCase
                     )
                 ))
             ),
+            // Does not match pattern
+            array(
+                json_encode(array(
+                        'regex_us' => false,
+                    )),
+                json_encode(array(
+                        'type' => 'object',
+                        'patternProperties' => array(
+                            '^[a-z]+_(jp|de)$' => array(
+                                'type' => array('boolean')
+                            )
+                        ),
+                        "additionalProperties" => false
+                    ))
+            ),
+            // An invalid regular expression pattern
+            array(
+                json_encode(array(
+                        'regex_us' => false,
+                    )),
+                json_encode(array(
+                        'type' => 'object',
+                        'patternProperties' => array(
+                            '^[a-z+_jp|de)$' => array(
+                                'type' => array('boolean')
+                            )
+                        ),
+                        "additionalProperties" => false
+                    ))
+            ),
         );
     }
 
@@ -72,6 +102,25 @@ class PatternPropertiesTest extends BaseTestCase
                         ),
                     )
                 ))
+            ),
+            array(
+                json_encode(array(
+                        'foobar' => true,
+                        'regex_us' => 'foo',
+                        'regex_de' => 1234
+                    )),
+                json_encode(array(
+                        'type' => 'object',
+                        'properties' => array(
+                            'foobar' => array('type' => 'boolean')
+                        ),
+                        'patternProperties' => array(
+                            '^[a-z]+_(us|de)$' => array(
+                                'type' => array('string', 'integer')
+                            )
+                        ),
+                        "additionalProperties" => false
+                    ))
             ),
         );
     }


### PR DESCRIPTION
This commit fixes issues with patternProperties that caused it to not work properly, failing on properties that satisfied the pattern regex. The patternProperties regex is validated using preg_match(). Now, patternProperties works correctly. New unit tests for positive and negative cases have been added to verify the changes.
