### PR TITLE
resolve relative uris and anchored schema uris

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -9,7 +9,9 @@
 
 namespace JsonSchema;
 
+use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Uri\Retrievers\UriRetrieverInterface;
+use JsonSchema\Exception\ResourceNotFoundException;
 
 /**
  * Take in an object that's a JSON schema and take care of all $ref references
@@ -41,7 +43,7 @@ class RefResolver
      */
     public function fetchRef($ref, $sourceUri)
     {
-        $retriever = $this->getUriRetriever();
+        $retriever  = $this->getUriRetriever();
         $jsonSchema = $retriever->retrieve($ref, $sourceUri);
         $this->resolve($jsonSchema);
 

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Uri\Retrievers;
 
+use JsonSchema\Exception\ResourceNotFoundException;
 use JsonSchema\Validator;
 
 /**
@@ -31,9 +32,14 @@ class FileGetContents implements UriRetrieverInterface
         
         $response = file_get_contents($uri);
         if (false === $response) {
-            throw new ResourceNotFoundException('JSON schema not found');
+            throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
         }
-        
+        if ($response == ''
+            && substr($uri, 0, 7) == 'file://' && substr($uri, -1) == '/'
+        ) {
+            throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
+        }
+
         $this->messageBody = $response;
 		if (! empty($http_response_header)) {
 			$this->fetchContentType($http_response_header);

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -184,4 +184,103 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
 			),
 		);
 	}
+
+    public function testFetchRefAbsolute()
+    {
+        $retr = new \JsonSchema\Uri\Retrievers\PredefinedArray(
+            array(
+                'http://example.org/schema' => <<<JSN
+{
+    "title": "schema",
+    "type": "object",
+    "id": "http://example.org/schema"
+}
+JSN
+            )
+        );
+
+        $res = new \JsonSchema\RefResolver();
+        $res->getUriRetriever()->setUriRetriever($retr);
+
+        $this->assertEquals(
+            (object) array(
+                'title' => 'schema',
+                'type'  => 'object',
+                'id'    => 'http://example.org/schema'
+            ),
+            $res->fetchRef('http://example.org/schema', 'http://example.org/schema')
+        );
+    }
+
+    public function testFetchRefAbsoluteAnchor()
+    {
+        $retr = new \JsonSchema\Uri\Retrievers\PredefinedArray(
+            array(
+                'http://example.org/schema' => <<<JSN
+{
+    "title": "schema",
+    "type": "object",
+    "id": "http://example.org/schema",
+    "definitions": {
+        "foo": {
+            "type": "object",
+            "title": "foo"
+        }
+    }
+}
+JSN
+            )
+        );
+
+        $res = new \JsonSchema\RefResolver();
+        $res->getUriRetriever()->setUriRetriever($retr);
+
+        $this->assertEquals(
+            (object) array(
+                'title' => 'foo',
+                'type'  => 'object',
+                'id'    => 'http://example.org/schema#/definitions/foo',
+            ),
+            $res->fetchRef(
+                'http://example.org/schema#/definitions/foo',
+                'http://example.org/schema'
+            )
+        );
+    }
+
+    public function testFetchRefRelativeAnchor()
+    {
+        $retr = new \JsonSchema\Uri\Retrievers\PredefinedArray(
+            array(
+                'http://example.org/schema' => <<<JSN
+{
+    "title": "schema",
+    "type": "object",
+    "id": "http://example.org/schema",
+    "definitions": {
+        "foo": {
+            "type": "object",
+            "title": "foo"
+        }
+    }
+}
+JSN
+            )
+        );
+
+        $res = new \JsonSchema\RefResolver();
+        $res->getUriRetriever()->setUriRetriever($retr);
+
+        $this->assertEquals(
+            (object) array(
+                'title' => 'foo',
+                'type'  => 'object',
+                'id'    => 'http://example.org/schema#/definitions/foo',
+            ),
+            $res->fetchRef(
+                '#/definitions/foo',
+                'http://example.org/schema'
+            )
+        );
+    }
 }

--- a/tests/JsonSchema/Tests/Uri/UriResolverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriResolverTest.php
@@ -1,0 +1,174 @@
+<?php
+namespace JsonSchema\Tests\Uri;
+
+use JsonSchema\Uri\UriResolver;
+
+class UriResolverTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->resolver = new UriResolver();
+    }
+
+    public function testParse()
+    {
+        $this->assertEquals(
+            array(
+                'scheme'    => 'http',
+                'authority' => 'example.org',
+                'path'      => '/path/to/file.json'
+            ),
+            $this->resolver->parse('http://example.org/path/to/file.json')
+        );
+    }
+
+    public function testParseAnchor()
+    {
+        $this->assertEquals(
+            array(
+                'scheme'    => 'http',
+                'authority' => 'example.org',
+                'path'      => '/path/to/file.json',
+                'query'     => '',
+                'fragment'  => 'foo'
+            ),
+            $this->resolver->parse('http://example.org/path/to/file.json#foo')
+        );
+    }
+
+    public function testCombineRelativePathWithBasePath()
+    {
+        $this->assertEquals(
+            '/foo/baz.json',
+            UriResolver::combineRelativePathWithBasePath(
+                'baz.json',
+                '/foo/bar.json'
+            )
+        );
+    }
+
+    public function testCombineRelativePathWithBasePathAbsolute()
+    {
+        $this->assertEquals(
+            '/baz/data.json',
+            UriResolver::combineRelativePathWithBasePath(
+                '/baz/data.json',
+                '/foo/bar.json'
+            )
+        );
+    }
+
+    public function testCombineRelativePathWithBasePathRelativeSub()
+    {
+        $this->assertEquals(
+            '/foo/baz/data.json',
+            UriResolver::combineRelativePathWithBasePath(
+                'baz/data.json',
+                '/foo/bar.json'
+            )
+        );
+    }
+
+    public function testCombineRelativePathWithBasePathNoPath()
+    {
+        //needed for anchor-only urls
+        $this->assertEquals(
+            '/foo/bar.json',
+            UriResolver::combineRelativePathWithBasePath(
+                '',
+                '/foo/bar.json'
+            )
+        );
+    }
+
+    public function testResolveAbsoluteUri()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json',
+            $this->resolver->resolve(
+                'http://example.org/foo/bar.json',
+                null
+            )
+        );
+    }
+
+    /**
+     * @expectedException JsonSchema\Exception\UriResolverException
+     */
+    public function testResolveRelativeUriNoBase()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json',
+            $this->resolver->resolve(
+                'bar.json',
+                null
+            )
+        );
+    }
+
+    public function testResolveRelativeUriBaseDir()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json',
+            $this->resolver->resolve(
+                'bar.json',
+                'http://example.org/foo/'
+            )
+        );
+    }
+
+    public function testResolveRelativeUriBaseFile()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json',
+            $this->resolver->resolve(
+                'bar.json',
+                'http://example.org/foo/baz.json'
+            )
+        );
+    }
+
+    public function testResolveAnchor()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json#baz',
+            $this->resolver->resolve(
+                '#baz',
+                'http://example.org/foo/bar.json'
+            )
+        );
+    }
+
+    public function testResolveAnchorWithFile()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/baz.json#baz',
+            $this->resolver->resolve(
+                'baz.json#baz',
+                'http://example.org/foo/bar.json'
+            )
+        );
+    }
+    public function testResolveAnchorAnchor()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json#bazinga',
+            $this->resolver->resolve(
+                '#bazinga',
+                'http://example.org/foo/bar.json#baz'
+            )
+        );
+    }
+
+    public function testResolveEmpty()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/bar.json',
+            $this->resolver->resolve(
+                '',
+                'http://example.org/foo/bar.json'
+            )
+        );
+    }
+}
+?>

--- a/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
@@ -144,4 +144,79 @@ EOF;
             array($childSchema, $parentSchema)
         );
     }
+
+    public function testResolvePointerNoFragment()
+    {
+        $schema = (object) array(
+            'title' => 'schema'
+        );
+
+        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $this->assertEquals(
+            $schema,
+            $retriever->resolvePointer(
+                $schema, 'http://example.org/schema.json'
+            )
+        );
+    }
+
+    public function testResolvePointerFragment()
+    {
+        $schema = (object) array(
+            'definitions' => (object) array(
+                'foo' => (object) array(
+                    'title' => 'foo'
+                )
+            ),
+            'title' => 'schema'
+        );
+
+        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $this->assertEquals(
+            $schema->definitions->foo,
+            $retriever->resolvePointer(
+                $schema, 'http://example.org/schema.json#/definitions/foo'
+            )
+        );
+    }
+
+    /**
+     * @expectedException JsonSchema\Exception\ResourceNotFoundException
+     */
+    public function testResolvePointerFragmentNotFound()
+    {
+        $schema = (object) array(
+            'definitions' => (object) array(
+                'foo' => (object) array(
+                    'title' => 'foo'
+                )
+            ),
+            'title' => 'schema'
+        );
+
+        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever->resolvePointer(
+            $schema, 'http://example.org/schema.json#/definitions/bar'
+        );
+    }
+
+    /**
+     * @expectedException JsonSchema\Exception\ResourceNotFoundException
+     */
+    public function testResolvePointerFragmentNoArray()
+    {
+        $schema = (object) array(
+            'definitions' => (object) array(
+                'foo' => array(
+                    'title' => 'foo'
+                )
+            ),
+            'title' => 'schema'
+        );
+
+        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever->resolvePointer(
+            $schema, 'http://example.org/schema.json#/definitions/foo'
+        );
+    }
 }


### PR DESCRIPTION
something like

```
"$ref": "base.json#/definitions/foo"
```

and

```
"$ref": "#/definitions/foo"
```

is supported now.

Tests provided, too.
