### PR TITLE
limit recursive expansion to 7 levels

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -20,6 +20,15 @@ use JsonSchema\Uri\Retrievers\UriRetrieverInterface;
 class RefResolver
 {
     /**
+     * HACK to prevent too many recursive expansions.
+     * Happens e.g. when you want to validate a schema against the schema
+     * definition.
+     *
+     * @var integer
+     */
+    protected static $depth = 0;
+
+    /**
      * @var UriRetrieverInterface
      */
     protected $uriRetriever = null;
@@ -79,7 +88,13 @@ class RefResolver
      */
     public function resolve($schema, $sourceUri = null)
     {
+        if (self::$depth > 7) {
+            return;
+        }
+        ++self::$depth;
+
         if (! is_object($schema)) {
+            --self::$depth;
             return;
         }
 
@@ -107,6 +122,8 @@ class RefResolver
         foreach (array('dependencies', 'patternProperties', 'properties') as $propertyName) {
             $this->resolveObjectOfSchemas($schema, $propertyName, $sourceUri);
         }
+
+        --self::$depth;
     }
 
     /**


### PR DESCRIPTION
The schema 04 definition is recursive. Expansion of the whole schema thus is impossible.

This patch limits the expansion to 7 levels, which should be ok as a temporary fix.
The correct solution is of course not to do expansion at all, but that will take much work.
