### PR TITLE
show path info in invalid-schema exception

### DIFF
--- a/src/JsonSchema/Constraints/Undefined.php
+++ b/src/JsonSchema/Constraints/Undefined.php
@@ -30,7 +30,10 @@ class Undefined extends Constraint
         }
 
         if (!is_object($schema)) {
-            throw new InvalidArgumentException('Given schema must be an object.');
+            throw new InvalidArgumentException(
+                'Given schema must be an object in ' . $path
+                . ' but is a ' . gettype($schema)
+            );
         }
 
         $i = is_null($i) ? "" : $i;


### PR DESCRIPTION
When receiving the information that a schema is not an object, it's nice to see where exactly the problem is.
