### PR TITLE
Fix for #62, #63, #64: automatically detect schema URL

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -122,7 +122,7 @@ if (count($arArgs) == 1) {
     $pathSchema = null;
 } else {
     $pathData   = $arArgs[0];
-    $pathSchema = $arArgs[1];
+    $pathSchema = getUrlFromPath($arArgs[1]);
 }
 
 $urlData = getUrlFromPath($pathData);


### PR DESCRIPTION
This patches add automatic schema URL detection to `bin/validate-json`.

Schema is detected from:
- "$schema" property in the root object
- "profile" property in the Content-Type header (once #61 has been implemented, see http://json-schema.org/latest/json-schema-core.html#anchor34)
- "describedBy" link header (once #61 has been implemented, see http://json-schema.org/latest/json-schema-core.html#anchor35)

This pull requests builds on:
- https://github.com/justinrainbow/json-schema/pull/70
- https://github.com/justinrainbow/json-schema/pull/71
- https://github.com/justinrainbow/json-schema/pull/72
- https://github.com/justinrainbow/json-schema/pull/73
- https://github.com/justinrainbow/json-schema/pull/74
