### PR TITLE
fixed "empty array"-bug

### DIFF
--- a/src/JsonSchema/Constraints/Collection.php
+++ b/src/JsonSchema/Constraints/Collection.php
@@ -101,9 +101,11 @@ class Collection extends Constraint
                 }
             }
 
-            // Treat when we have more schema definitions than values
-            for ($k = count($value); $k < count($schema->items); $k++) {
-                $this->checkUndefined(new Undefined(), $schema->items[$k], $path, $k);
+            // Treat when we have more schema definitions than values, not for empty arrays
+            if(count($value) > 0) {
+                for ($k = count($value); $k < count($schema->items); $k++) {
+                    $this->checkUndefined(new Undefined(), $schema->items[$k], $path, $k);
+                }
             }
         }
     }


### PR DESCRIPTION
This fixes a bug with valid empty JSON arrays.

Example: 

This JSON
{"cars":[]}

violates this schema
{
    "description": "cars",
    "type": "object",
    "properties": {
        "cars": {
            "type": "array",
            "required": true,
            "minItems": 0,
            "items": [
                {
                    "type": "object",
                    "required": true,
                    "properties": {
                        "carBrand": {
                            "type": "string",
                            "required": true
                        },
                        "carModel": {
                            "type": "string",
                            "required": true
}}}]}}}

with this error
cars[0] - is missing and it is required
