### PR TITLE
Add failing test case

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
+++ b/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
@@ -266,6 +266,28 @@ class RequiredPropertyTest extends BaseTestCase
                         "foo": { "required": true }
                     }
                 }'
+            ),
+            array(
+                '{
+                    "prop1": "abc"
+                }',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "prop1": {"type": "string"},
+                        "prop2": {
+                            "oneOf": [
+                                {
+                                    "type": "number"
+                                },
+                                {
+                                    "type": "string"
+                                }
+                            ]
+                        }
+                    },
+                    "required": ["prop1"]
+                }'
             )
         );
     }


### PR DESCRIPTION
An optional property that contains a oneOf (probably also with anyOf,
etc) will cause failure if it is not present. In other words, a property
that is not listed as required causes validation errors if omitted.
