### PR TITLE
Validation with oneOf, allOf and anyOf only if property is set

### DIFF
--- a/src/JsonSchema/Constraints/Undefined.php
+++ b/src/JsonSchema/Constraints/Undefined.php
@@ -195,6 +195,11 @@ class Undefined extends Constraint
      */
     protected function validateOfProperties($value, $schema, $path, $i = "")
     {
+        // Verify type
+        if ($value instanceof Undefined) {
+            return;
+        }
+
         if (isset($schema->allOf)) {
             $isValid = true;
             foreach ($schema->allOf as $allOf) {

--- a/tests/JsonSchema/Tests/Constraints/OfPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/OfPropertiesTest.php
@@ -1,0 +1,92 @@
+<?php
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace JsonSchema\Tests\Constraints;
+
+use JsonSchema\Validator;
+
+/**
+ * Class OfPropertiesTest
+ */
+class OfPropertiesTest extends BaseTestCase
+{
+
+    public function getValidTests()
+    {
+        return array(
+            array(
+                '{"prop1": "abc"}',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "prop1": {"type": "string"},
+                    "prop2": {
+                      "oneOf": [
+                        {"type": "number"},
+                        {"type": "string"}
+                      ]
+                    }
+                  },
+                  "required": ["prop1"]
+                }'
+            ),
+            array(
+                '{"prop1": "abc", "prop2": 23}',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "prop1": {"type": "string"},
+                    "prop2": {
+                      "oneOf": [
+                        {"type": "number"},
+                        {"type": "string"}
+                      ]
+                    }
+                  },
+                  "required": ["prop1"]
+                }'
+            ),
+        );
+    }
+
+    public function getInvalidTests()
+    {
+        return array(
+            array(
+                '{"prop1": "abc", "prop2": []}',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "prop1": {"type": "string"},
+                    "prop2": {
+                      "oneOf": [
+                        {"type": "number"},
+                        {"type": "string"}
+                      ]
+                    }
+                  },
+                  "required": ["prop1"]
+                }',
+                Validator::CHECK_MODE_NORMAL,
+                array(
+                    array(
+                        "property" => "prop2",
+                        "message"  => "array value found, but a number is required",
+                    ),
+                    array(
+                        "property" => "prop2",
+                        "message"  => "array value found, but a string is required",
+                    ),
+                    array(
+                        "property" => "prop2",
+                        "message"  => "failed to match exactly one schema",
+                    ),
+                ),
+            ),
+        );
+    }
+}


### PR DESCRIPTION
Added check if property is defined before values are checked with ofProperty validators

Fixes https://github.com/justinrainbow/json-schema/issues/81
