### PR TITLE
add specific php version 5.3.3 to travis build to validate issue #84

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: php
 
 php:
+  - 5.3.3
   - 5.3
   - 5.4
   - 5.5
@@ -8,7 +9,7 @@ php:
 before_script:
   - sudo apt-get -y install pypy python-sphinx graphviz
   - composer selfupdate
-  - composer install
+  - composer install --prefer-source
 
 script:
   - cd docs && make linkcheck && cd ..


### PR DESCRIPTION
This leads to a failing build. 

The build is fixed by #85 (tested via the combined branch alexmmm/json-schema@a2982e89534a7f6d2748be0fd8156721a53596b1)

Also added composer install option '--prefer-source',to avoid ssl issues in php 5.3.3.
