### PR TITLE
Add missing required property names to errors

### DIFF
--- a/src/JsonSchema/Constraints/Undefined.php
+++ b/src/JsonSchema/Constraints/Undefined.php
@@ -121,7 +121,7 @@ class Undefined extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError($path, "the property " . $required . " is required");
+                        $this->addError($required, "required field");
                     }
                 }
             } else if (isset($schema->required)) {


### PR DESCRIPTION
In cases where required properties are missing, the `property` keys in `$this->errors` should contain the names of the missing properties rather than an empty string. This would help a lot for parsing purposes.