### PR TITLE
Use mb_strlen instead of strlen when mbstring extension is available.

### DIFF
--- a/src/JsonSchema/Constraints/String.php
+++ b/src/JsonSchema/Constraints/String.php
@@ -23,12 +23,12 @@ class String extends Constraint
     public function check($element, $schema = null, $path = null, $i = null)
     {
         // Verify maxLength
-        if (isset($schema->maxLength) && strlen($element) > $schema->maxLength) {
+        if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
             $this->addError($path, "must be at most " . $schema->maxLength . " characters long");
         }
 
         //verify minLength
-        if (isset($schema->minLength) && strlen($element) < $schema->minLength) {
+        if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
             $this->addError($path, "must be at least " . $schema->minLength . " characters long");
         }
 
@@ -38,5 +38,14 @@ class String extends Constraint
         }
 
         $this->checkFormat($element, $schema, $path, $i);
+    }
+
+    private function strlen($string)
+    {
+        if (extension_loaded('mbstring')) {
+            return mb_strlen($string, mb_detect_encoding($string));
+        } else {
+            return strlen($string);
+        }
     }
 }

--- a/tests/JsonSchema/Tests/Constraints/MinLengthMaxLengthMultiByteTest.php
+++ b/tests/JsonSchema/Tests/Constraints/MinLengthMaxLengthMultiByteTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+class MinLengthMaxLengthMultiByteTest extends BaseTestCase
+{
+    protected function setUp()
+    {
+        if (! extension_loaded('mbstring')) {
+            $this->markTestSkipped('mbstring extension is not available');
+        }
+    }
+
+    public function getInvalidTests()
+    {
+        return array(
+            array(
+                '{
+                  "value":"☀"
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","minLength":2,"maxLength":4}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value":"☀☁☂☃☺"
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","minLength":2,"maxLength":4}
+                  }
+                }'
+            )
+        );
+    }
+
+    public function getValidTests()
+    {
+        return array(
+            array(
+                '{
+                  "value":"☀☁"
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","minLength":2,"maxLength":4}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value":"☀☁☂☃"
+                }',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","minLength":2,"maxLength":4}
+                  }
+                }'
+            )
+        );
+    }
+}


### PR DESCRIPTION
strlen() returns the number of bytes, not the number of characters.
This causes a problem when a multibyte string is supplied to string length validation.

mb_strlen() counts the number of characters, so is suitable for minLength/maxLength check.
I modified to use mb_strlen() when mbstring extension is loaded.
