### PR TITLE
replace  invalid filesystem dependent directory separator  references

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -126,7 +126,7 @@ class UriResolver
         $basePathSegments = array_slice($basePathSegments, 0, -$numLevelUp);
         $path = preg_replace('|^/?(\.\./(\./)*)*|', '', $relativePath);
 
-        return implode(DIRECTORY_SEPARATOR, $basePathSegments) . '/' . $path;
+        return implode('/', $basePathSegments) . '/' . $path;
     }
 
     /**
@@ -148,7 +148,7 @@ class UriResolver
      */
     private static function getPathSegments($path) {
         
-        return explode(DIRECTORY_SEPARATOR, $path);
+        return explode('/', $path);
     }
     
     /**

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -282,7 +282,7 @@ class UriRetriever
         $basePathSegments = array_slice($basePathSegments, 0, -$numLevelUp);
         $path = preg_replace('|^/?(\.\./(\./)*)*|', '', $relativePath);
 
-        return implode(DIRECTORY_SEPARATOR, $basePathSegments) . '/' . $path;
+        return implode('/', $basePathSegments) . '/' . $path;
     }
 
     /**
@@ -304,7 +304,7 @@ class UriRetriever
      */
     private static function getPathSegments($path)
     {
-        return explode(DIRECTORY_SEPARATOR, $path);
+        return explode('/', $path);
     }
 
     /**


### PR DESCRIPTION
Fixes failing UriResolver tests on windows systems and removes file system dependency from uri explode/implode processes,
