### PR TITLE
Fix UriRetriever::combineRelativePathWithBasePath() does not qualify UriResolverException

### DIFF
--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -276,7 +276,7 @@ class UriRetriever
         preg_match('|^/?(\.\./(?:\./)*)*|', $relativePath, $match);
         $numLevelUp = strlen($match[0]) /3 + 1;
         if ($numLevelUp >= count($basePathSegments)) {
-            throw new UriResolverException(sprintf("Unable to resolve URI '%s' from base '%s'", $relativePath, $basePath));
+            throw new \JsonSchema\Exception\UriResolverException(sprintf("Unable to resolve URI '%s' from base '%s'", $relativePath, $basePath));
         }
 
         $basePathSegments = array_slice($basePathSegments, 0, -$numLevelUp);

--- a/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
@@ -222,4 +222,15 @@ EOF;
             $schema, 'http://example.org/schema.json#/definitions/foo'
         );
     }
+    
+    /**
+     * @expectedException JsonSchema\Exception\UriResolverException
+     */
+    public function testResolveExcessLevelUp()
+    {
+        $retriever = new \JsonSchema\Uri\UriRetriever();
+        $retriever->resolve(
+            '../schema.json#', 'http://example.org/schema.json#'
+        );
+    }
 }


### PR DESCRIPTION
The UriResolverException class is not qualified or aliased when it is thrown in UriRetriever::combineRelativePathWithBasePath(), and it is likely to fail to load.

(This is the first pull request I've created, so please let me know if I've erred.)
