### PR TITLE
added property callback mechanism

### DIFF
--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -114,7 +114,7 @@ abstract class Constraint implements ConstraintInterface
      * @param $i
      */
     protected function call_user_properties($schema, $element, $path, $i){
-        if (count($GLOBALS['Validator_Properties'])>0){
+        if (isset($GLOBALS['Validator_Properties']) && count($GLOBALS['Validator_Properties'])>0){
             foreach($GLOBALS['Validator_Properties'] as $key=>$value){
                 if (isset($schema->$key)) {
                     $result = call_user_func($value, $key, $element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -94,6 +94,34 @@ abstract class Constraint implements ConstraintInterface
     }
 
     /**
+     * Registers properties into a global (so it doesn't have to be pulled everywhere)
+     * @param $property_name - name to register
+     * @param $callback - callback function to register
+     */
+    public function register_property($property_name, $callback)
+    {
+        if (is_callable($callback))
+            $GLOBALS['Validator_Properties'][$property_name] = $callback;
+    }
+
+    /**
+     * Shared function to call the user property callback
+     * @param $schema
+     * @param $element
+     * @param $path
+     * @param $i
+     */
+    protected function call_user_properties($schema, $element, $path, $i){
+        if (count($GLOBALS['Validator_Properties'])>0){
+            foreach($GLOBALS['Validator_Properties'] as $key=>$value){
+                if (isset($schema->$key)) {
+                    call_user_func($value, $key, $element, $schema, $path, $i);
+                }
+            }
+        }
+    }
+
+    /**
      * Clears any reported errors.  Should be used between
      * multiple validation checks.
      */

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -106,6 +106,8 @@ abstract class Constraint implements ConstraintInterface
 
     /**
      * Shared function to call the user property callback
+     * user function returns an associative error array
+     *
      * @param $schema
      * @param $element
      * @param $path
@@ -115,7 +117,12 @@ abstract class Constraint implements ConstraintInterface
         if (count($GLOBALS['Validator_Properties'])>0){
             foreach($GLOBALS['Validator_Properties'] as $key=>$value){
                 if (isset($schema->$key)) {
-                    call_user_func($value, $key, $element, $schema, $path, $i);
+                    $result = call_user_func($value, $key, $element, $schema, $path, $i);
+                    if (is_array($result) && count($result)>0){
+                        foreach($result as $rkey=>$rvalue){
+                            $this->addError($rkey, $rvalue);
+                        }
+                    }
                 }
             }
         }

--- a/src/JsonSchema/Constraints/Number.php
+++ b/src/JsonSchema/Constraints/Number.php
@@ -62,6 +62,8 @@ class Number extends Constraint
             $this->addError($path, "must be a multiple of " . $schema->multipleOf);
         }
 
+        $this->call_user_properties($schema, $element, $path, $i);
+
         $this->checkFormat($element, $schema, $path, $i);
     }
 

--- a/src/JsonSchema/Constraints/String.php
+++ b/src/JsonSchema/Constraints/String.php
@@ -37,6 +37,8 @@ class String extends Constraint
             $this->addError($path, "does not match the regex pattern " . $schema->pattern);
         }
 
+        $this->call_user_properties($schema, $element, $path, $i);
+
         $this->checkFormat($element, $schema, $path, $i);
     }
 


### PR DESCRIPTION
Registered properties, when encountered by the validator, fires the callback function.

Usage:
```
$validator = new JsonSchema\Validator();
$validator->register_property('db_uniqueness',function($key, $element, $schema, $path, $i){
    // callback magick here

    // callback determines there are errors, so return them
    return array($key=>'random error 1', $key=>'specific error');
});
$validator->check($obj, $schema);
```