### PR TITLE
Added missed symbol for query string.

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -59,7 +59,7 @@ class UriResolver
              . $components['path'];
         
         if (array_key_exists('query', $components)) {
-            $uri .= $components['query'];
+            $uri .= '?' . $components['query'];
         }
         if (array_key_exists('fragment', $components)) {
             $uri .= '#' . $components['fragment'];


### PR DESCRIPTION
Without it uri like "$ref":"http://hostname/some/path?some=param" resolves into "http://hostname/some/pathsome=param".