### PR TITLE
Fix #93 ($ref to local definition not working)

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -244,7 +244,7 @@ class RefResolver
             return $data;
         }
 
-        $key = array_shift($pathParts);
+        $key = $this->transformKey(array_shift($pathParts));
 
         return $this->resolveRefSegment(is_array($data) ? $data[$key] : $data->$key,  $pathParts);
     }
@@ -260,5 +260,13 @@ class RefResolver
         $this->uriRetriever = $retriever;
 
         return $this;
+    }
+
+    protected function transformKey($key)
+    {
+        return strtr($key, [
+            '~1' => '/',
+            '~0' => '~',
+        ]);
     }
 }

--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -264,9 +264,9 @@ class RefResolver
 
     protected function transformKey($key)
     {
-        return strtr($key, [
+        return strtr($key, array(
             '~1' => '/',
             '~0' => '~',
-        ]);
+        ));
     }
 }

--- a/tests/JsonSchema/Tests/Drafts/Draft4Test.php
+++ b/tests/JsonSchema/Tests/Drafts/Draft4Test.php
@@ -25,5 +25,39 @@ class Draft4Test extends BaseDraftTestCase
             'zeroTerminatedFloats.json'
         );
     }
+    
+    public function testInnerDefinitions(){
+        $schema = <<<JSN
+{
+    "type": "object",
+    "additionalProperties":false,
+    "properties": {
+        "person": { "\$ref": "#/definitions/persondef" }
+    },
+    "definitions": {
+        "persondef": {
+            "type": "object",
+            "additionalProperties":false,
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "age": {
+                    "type" : "integer"
+                }
+            }
+        }
+    }
+}
+JSN;
+        $schemaObj = json_decode($schema);
+        $resolver = new \JsonSchema\RefResolver();
+        $resolver->resolve($schemaObj);
+        
+        $schema = json_encode($schemaObj);
+        
+        $this->testValidCases('{"person": {"name" : "John Doe", "age" : 30} }', $schema);
+        $this->testInvalidCases('{"person": {"name" : "John Doe", "age" : "wrong"} }', $schema);
+    }
 
 }

--- a/tests/JsonSchema/Tests/Drafts/Draft4Test.php
+++ b/tests/JsonSchema/Tests/Drafts/Draft4Test.php
@@ -32,7 +32,8 @@ class Draft4Test extends BaseDraftTestCase
     "type": "object",
     "additionalProperties":false,
     "properties": {
-        "person": { "\$ref": "#/definitions/persondef" }
+        "person": { "\$ref": "#/definitions/persondef" },
+        "person-age": { "\$ref": "#/definitions/persondef/properties/age" }
     },
     "definitions": {
         "persondef": {
@@ -58,6 +59,8 @@ JSN;
         
         $this->testValidCases('{"person": {"name" : "John Doe", "age" : 30} }', $schema);
         $this->testInvalidCases('{"person": {"name" : "John Doe", "age" : "wrong"} }', $schema);
+        $this->testValidCases('{"person-age": 30 }', $schema);
+        $this->testInvalidCases('{"person-age": "wrong" }', $schema);
     }
 
 }

--- a/tests/JsonSchema/Tests/Drafts/Draft4Test.php
+++ b/tests/JsonSchema/Tests/Drafts/Draft4Test.php
@@ -33,7 +33,9 @@ class Draft4Test extends BaseDraftTestCase
     "additionalProperties":false,
     "properties": {
         "person": { "\$ref": "#/definitions/persondef" },
-        "person-age": { "\$ref": "#/definitions/persondef/properties/age" }
+        "person-age": { "\$ref": "#/definitions/persondef/properties/age" },
+        "slash": { "\$ref": "#/definitions/persondef/properties/~1slash" },
+        "tilde": { "\$ref": "#/definitions/persondef/properties/~0tilde" }
     },
     "definitions": {
         "persondef": {
@@ -44,6 +46,12 @@ class Draft4Test extends BaseDraftTestCase
                     "type": "string"
                 },
                 "age": {
+                    "type" : "integer"
+                },
+                "/slash": {
+                    "type" : "integer"
+                },
+                "~tilde": {
                     "type" : "integer"
                 }
             }
@@ -61,6 +69,10 @@ JSN;
         $this->testInvalidCases('{"person": {"name" : "John Doe", "age" : "wrong"} }', $schema);
         $this->testValidCases('{"person-age": 30 }', $schema);
         $this->testInvalidCases('{"person-age": "wrong" }', $schema);
+        $this->testValidCases('{"slash": 30 }', $schema);
+        $this->testInvalidCases('{"slash": "wrong" }', $schema);
+        $this->testValidCases('{"tilde": 30 }', $schema);
+        $this->testInvalidCases('{"tilde": "wrong" }', $schema);
     }
 
 }


### PR DESCRIPTION
See also #110. This pull request is based @stoiev's branch. First, thanks for his great work!
(I skipped fc947a6c949af5302d81e8b3b409d5ead76bc0ca commit. Because it is not related with this problem and it contains some problems; composer.lock should not be ignored (see http://blog.naderman.de/2014/02/17/replace-conflict-forks-explained/) and netbeans project directories  should be ignored in $HOME/.gitignore)

And I've referenced some implementation of brandur/json_schema (it is Ruby JSON Schema validation library). I really appreciate to the library.

My fix resolves some problems of #110; e.g. the #110 implementation only resolves the top level of $ref but my implementation resolves any level of a path.

But, however, it doesn't pass json/tests/draft4/ref.json yet. We should effort resolve this problem too, but the inline dereferencing problem is needed to fix ASAP.