### PR TITLE
Add `properties` for resolveProperty()

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -114,7 +114,7 @@ class RefResolver
 
         // These properties are just schemas
         // eg.  items can be a schema or an array of schemas
-        foreach (array('additionalItems', 'additionalProperties', 'extends', 'items') as $propertyName) {
+        foreach (array('additionalItems', 'additionalProperties', 'extends', 'items', 'properties') as $propertyName) {
             $this->resolveProperty($schema, $propertyName, $sourceUri);
         }
 

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -42,7 +42,7 @@ class RefResolverTest extends \PHPUnit_Framework_TestCase
                 (object) array(),
                 array(
                     'resolveRef' => 1,
-                    'resolveProperty' => 4,
+                    'resolveProperty' => 5,
                     'resolveArrayOfSchemas' => 7,
                     'resolveObjectOfSchemas' => 3
                 )


### PR DESCRIPTION
Hi for all. This PR closer to question, than for advice or patch :)

```JSON
	"$schema": "http://json-schema.org/draft-04/schema",
	"definitions" : {
		"someObject": {
			"type": "object",
			"additionalProperties": true,
			"properties":  {
				/*a_lot_of_properties*/
			}
		}
	},
	"type": "object",
	"required": true,
	"additionalProperties":: true,
	"properties": {
		"entity" : {
			"type": ["object", "null"],
			"required": true,
			"additionalProperties": true,
			"properties": {
				"someObj" : {
					"type": ["array", "object"],
					"required": true,
					"items" : {
						"$ref" : "#/definitions/someObject"
					},
					"properties" : {
						"$ref" : "#/definitions/someObject"
					}
				}
			},
```
Resolver now is not resolving ``$ref`` at the ``properties`` key. What is the reason, that i could not take all ``properties`` from definitions and put to ``some object -> properties``?