### PR TITLE
Make the enum element comparison strict

### DIFF
--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -23,13 +23,21 @@ class EnumConstraint extends Constraint
     public function check($element, $schema = null, $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
-        if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required))  {
+        if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {
             return;
         }
 
         foreach ($schema->enum as $enum) {
-            if ((gettype($element) === gettype($enum)) && ($element === $enum)) {
-                return;
+            $type = gettype($element);
+            if ($type === gettype($enum)) {
+                if ($type == "object") {
+                    if ($element == $enum)
+                        return;
+                } else {
+                    if ($element === $enum)
+                        return;
+
+                }
             }
         }
 

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -28,7 +28,7 @@ class EnumConstraint extends Constraint
         }
 
         foreach ($schema->enum as $enum) {
-            if ((gettype($element) === gettype($enum)) && ($element == $enum)) {
+            if ((gettype($element) === gettype($enum)) && ($element === $enum)) {
                 return;
             }
         }


### PR DESCRIPTION
The current check is matching numeric strings that are not equal ( like "604.1" == "604.10" because of PHP's == behavior that converts numeric strings to numbers and then performs a numeric comparison), even if type is checked before the comparison, the value should be identic