### PR TITLE
[Proposal] new constraints name - for PHP7

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -10,12 +10,12 @@
 namespace JsonSchema\Constraints;
 
 /**
- * The Collection Constraints, validates an array against a given schema
+ * The CollectionConstraint Constraints, validates an array against a given schema
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Collection extends Constraint
+class CollectionConstraint extends Constraint
 {
     /**
      * {@inheritDoc}
@@ -104,7 +104,7 @@ class Collection extends Constraint
             // Treat when we have more schema definitions than values, not for empty arrays
             if(count($value) > 0) {
                 for ($k = count($value); $k < count($schema->items); $k++) {
-                    $this->checkUndefined(new Undefined(), $schema->items[$k], $path, $k);
+                    $this->checkUndefined(new UndefinedConstraint(), $schema->items[$k], $path, $k);
                 }
             }
         }

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -137,7 +137,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkArray($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Collection($this->checkMode, $this->uriRetriever);
+        $validator = new CollectionConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -154,7 +154,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkObject($value, $schema = null, $path = null, $i = null, $patternProperties = null)
     {
-        $validator = new Object($this->checkMode, $this->uriRetriever);
+        $validator = new ObjectConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i, $patternProperties);
 
         $this->addErrors($validator->getErrors());
@@ -170,7 +170,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkType($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Type($this->checkMode, $this->uriRetriever);
+        $validator = new TypeConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -186,7 +186,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkUndefined($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Undefined($this->checkMode, $this->uriRetriever);
+        $validator = new UndefinedConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -202,7 +202,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkString($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new String($this->checkMode, $this->uriRetriever);
+        $validator = new StringConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -218,7 +218,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkNumber($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Number($this->checkMode, $this->uriRetriever);
+        $validator = new NumberConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -234,7 +234,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkEnum($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Enum($this->checkMode, $this->uriRetriever);
+        $validator = new EnumConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -242,7 +242,7 @@ abstract class Constraint implements ConstraintInterface
 
     protected function checkFormat($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Format($this->checkMode, $this->uriRetriever);
+        $validator = new FormatConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -10,12 +10,12 @@
 namespace JsonSchema\Constraints;
 
 /**
- * The Enum Constraints, validates an element against a given set of possibilities
+ * The EnumConstraint Constraints, validates an element against a given set of possibilities
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Enum extends Constraint
+class EnumConstraint extends Constraint
 {
     /**
      * {@inheritDoc}
@@ -23,7 +23,7 @@ class Enum extends Constraint
     public function check($element, $schema = null, $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
-        if ($element instanceof Undefined && (!isset($schema->required) || !$schema->required))  {
+        if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required))  {
             return;
         }
 

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -15,7 +15,7 @@ namespace JsonSchema\Constraints;
  * @author Justin Rainbow <justin.rainbow@gmail.com>
  * @link   http://tools.ietf.org/html/draft-zyp-json-schema-03#section-5.23
  */
-class Format extends Constraint
+class FormatConstraint extends Constraint
 {
     /**
      * {@inheritDoc}

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -10,12 +10,12 @@
 namespace JsonSchema\Constraints;
 
 /**
- * The Number Constraints, validates an number against a given schema
+ * The NumberConstraint Constraints, validates an number against a given schema
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Number extends Constraint
+class NumberConstraint extends Constraint
 {
     /**
      * {@inheritDoc}

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -10,19 +10,19 @@
 namespace JsonSchema\Constraints;
 
 /**
- * The Object Constraints, validates an object against a given schema
+ * The ObjectConstraint Constraints, validates an object against a given schema
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Object extends Constraint
+class ObjectConstraint extends Constraint
 {
     /**
      * {@inheritDoc}
      */
     function check($element, $definition = null, $path = null, $additionalProp = null, $patternProperties = null)
     {
-        if ($element instanceof Undefined) {
+        if ($element instanceof UndefinedConstraint) {
             return;
         }
 
@@ -64,7 +64,7 @@ class Object extends Constraint
      *
      * @param \stdClass $element          Element to validate
      * @param array     $matches          Matches from patternProperties (if any)
-     * @param \stdClass $objectDefinition Object definition
+     * @param \stdClass $objectDefinition ObjectConstraint definition
      * @param string    $path             Path to test?
      * @param mixed     $additionalProp   Additional properties
      */
@@ -72,7 +72,7 @@ class Object extends Constraint
     {
         foreach ($element as $i => $value) {
 
-            $property = $this->getProperty($element, $i, new Undefined());
+            $property = $this->getProperty($element, $i, new UndefinedConstraint());
             $definition = $this->getProperty($objectDefinition, $i);
 
             // no additional properties allowed
@@ -106,13 +106,13 @@ class Object extends Constraint
      * Validates the definition properties
      *
      * @param \stdClass $element          Element to validate
-     * @param \stdClass $objectDefinition Object definition
+     * @param \stdClass $objectDefinition ObjectConstraint definition
      * @param string    $path             Path?
      */
     public function validateDefinition($element, $objectDefinition = null, $path = null)
     {
         foreach ($objectDefinition as $i => $value) {
-            $property = $this->getProperty($element, $i, new Undefined());
+            $property = $this->getProperty($element, $i, new UndefinedConstraint());
             $definition = $this->getProperty($objectDefinition, $i);
             $this->checkUndefined($property, $definition, $path, $i);
         }

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -12,12 +12,12 @@ namespace JsonSchema\Constraints;
 use JsonSchema\Exception\InvalidArgumentException;
 
 /**
- * The Schema Constraints, validates an element against a given schema
+ * The SchemaConstraint Constraints, validates an element against a given schema
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Schema extends Constraint
+class SchemaConstraint extends Constraint
 {
     /**
      * {@inheritDoc}

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -10,12 +10,12 @@
 namespace JsonSchema\Constraints;
 
 /**
- * The String Constraints, validates an string against a given schema
+ * The StringConstraint Constraints, validates an string against a given schema
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class String extends Constraint
+class StringConstraint extends Constraint
 {
     /**
      * {@inheritDoc}

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -13,12 +13,12 @@ use JsonSchema\Exception\InvalidArgumentException;
 use UnexpectedValueException as StandardUnexpectedValueException;
 
 /**
- * The Type Constraints, validates an element against a given type
+ * The TypeConstraint Constraints, validates an element against a given type
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Type extends Constraint
+class TypeConstraint extends Constraint
 {
     /**
      * @var array|string[] type wordings for validation error messages
@@ -48,7 +48,7 @@ class Type extends Constraint
             $validatedOneType = false;
             $errors = array();
             foreach ($type as $tp) {
-                $validator = new Type($this->checkMode);
+                $validator = new TypeConstraint($this->checkMode);
                 $subSchema = new \stdClass();
                 $subSchema->type = $tp;
                 $validator->check($value, $subSchema, $path, null);
@@ -88,7 +88,7 @@ class Type extends Constraint
      * Verifies that a given value is of a certain type
      *
      * @param mixed  $value Value to validate
-     * @param string $type  Type to check against
+     * @param string $type  TypeConstraint to check against
      *
      * @return boolean
      *

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -13,12 +13,12 @@ use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Uri\UriResolver;
 
 /**
- * The Undefined Constraints
+ * The UndefinedConstraint Constraints
  *
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
-class Undefined extends Constraint
+class UndefinedConstraint extends Constraint
 {
     /**
      * {@inheritDoc}
@@ -118,7 +118,7 @@ class Undefined extends Constraint
         // Verify required values
         if (is_object($value)) {
 
-            if (!($value instanceof Undefined) && isset($schema->required) && is_array($schema->required) ) {
+            if (!($value instanceof UndefinedConstraint) && isset($schema->required) && is_array($schema->required) ) {
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
@@ -127,14 +127,14 @@ class Undefined extends Constraint
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
-                if ( $schema->required && $value instanceof Undefined) {
+                if ( $schema->required && $value instanceof UndefinedConstraint) {
                     $this->addError($path, "is missing and it is required");
                 }
             }
         }
 
         // Verify type
-        if (!($value instanceof Undefined)) {
+        if (!($value instanceof UndefinedConstraint)) {
             $this->checkType($value, $schema, $path);
         }
 
@@ -197,7 +197,7 @@ class Undefined extends Constraint
     protected function validateOfProperties($value, $schema, $path, $i = "")
     {
         // Verify type
-        if ($value instanceof Undefined) {
+        if ($value instanceof UndefinedConstraint) {
             return;
         }
 

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -9,7 +9,7 @@
 
 namespace JsonSchema;
 
-use JsonSchema\Constraints\Schema;
+use JsonSchema\Constraints\SchemaConstraint;
 use JsonSchema\Constraints\Constraint;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
@@ -37,7 +37,7 @@ class Validator extends Constraint
      */
     public function check($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new Schema($this->checkMode, $this->uriRetriever);
+        $validator = new SchemaConstraint($this->checkMode, $this->uriRetriever);
         $validator->check($value, $schema);
 
         $this->addErrors(array_unique($validator->getErrors(), SORT_REGULAR));

--- a/tests/JsonSchema/Tests/Constraints/FormatTest.php
+++ b/tests/JsonSchema/Tests/Constraints/FormatTest.php
@@ -9,7 +9,7 @@
 
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Constraints\Format;
+use JsonSchema\Constraints\FormatConstraint;
 
 class FormatTest extends BaseTestCase
 {
@@ -20,7 +20,7 @@ class FormatTest extends BaseTestCase
     
     public function testNullThing()
     {
-        $validator = new Format();
+        $validator = new FormatConstraint();
         $schema = new \stdClass;
 
         $validator->check('10', $schema);
@@ -29,7 +29,7 @@ class FormatTest extends BaseTestCase
 
     public function testRegex()
     {
-        $validator = new Format();
+        $validator = new FormatConstraint();
         $schema = new \stdClass;
         $schema->format = 'regex';
 
@@ -45,7 +45,7 @@ class FormatTest extends BaseTestCase
      */
     public function testValidFormat($string, $format)
     {
-        $validator = new Format();
+        $validator = new FormatConstraint();
         $schema = new \stdClass;
         $schema->format = $format;
 
@@ -58,7 +58,7 @@ class FormatTest extends BaseTestCase
      */
     public function testInvalidFormat($string, $format)
     {
-        $validator = new Format();
+        $validator = new FormatConstraint();
         $schema = new \stdClass;
         $schema->format = $format;
 

--- a/tests/JsonSchema/Tests/Constraints/TypeTest.php
+++ b/tests/JsonSchema/Tests/Constraints/TypeTest.php
@@ -9,7 +9,7 @@
 
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Constraints\Type;
+use JsonSchema\Constraints\TypeConstraint;
 
 /**
  * Class TypeTest
@@ -41,7 +41,7 @@ class TypeTest extends \PHPUnit_Framework_TestCase
      */
     public function testIndefiniteArticleForTypeInTypeCheckErrorMessage($type, $wording, $value = null, $label = 'NULL')
     {
-        $constraint = new Type();
+        $constraint = new TypeConstraint();
         $constraint->check($value, (object)array('type' => $type));
         $this->assertTypeConstraintError("$label value found, but $wording $type is required", $constraint);
     }
@@ -50,9 +50,9 @@ class TypeTest extends \PHPUnit_Framework_TestCase
      * Helper to assert an error message
      *
      * @param string $expected
-     * @param Type $actual
+     * @param TypeConstraint $actual
      */
-    private function assertTypeConstraintError($expected, Type $actual)
+    private function assertTypeConstraintError($expected, TypeConstraint $actual)
     {
         $actualErrors = $actual->getErrors();
 


### PR DESCRIPTION
All constraints objects are now suffixed with *Constraint so we aint running into reserved words.
Suffixed Constraint to all contraints and not just "String"

Will fix #128 