### PR TITLE
Add constraint factory

### DIFF
--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -28,13 +28,20 @@ abstract class Constraint implements ConstraintInterface
     const CHECK_MODE_TYPE_CAST = 2;
 
     /**
+     * @var null|Factory
+     */
+    private $factory;
+
+    /**
      * @param int          $checkMode
      * @param UriRetriever $uriRetriever
+     * @param Factory      $factory
      */
-    public function __construct($checkMode = self::CHECK_MODE_NORMAL, UriRetriever $uriRetriever = null)
+    public function __construct($checkMode = self::CHECK_MODE_NORMAL, UriRetriever $uriRetriever = null, Factory $factory = null)
     {
         $this->checkMode    = $checkMode;
         $this->uriRetriever = $uriRetriever;
+        $this->factory = $factory;
     }
 
     /**
@@ -48,6 +55,18 @@ abstract class Constraint implements ConstraintInterface
         }
 
         return $this->uriRetriever;
+    }
+
+    /**
+     * @return Factory
+     */
+    public function getFactory()
+    {
+        if (!$this->factory) {
+            $this->factory = new Factory($this->getUriRetriever());
+        }
+
+        return $this->factory;
     }
 
     /**
@@ -137,7 +156,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkArray($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new CollectionConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('collection');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -154,7 +173,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkObject($value, $schema = null, $path = null, $i = null, $patternProperties = null)
     {
-        $validator = new ObjectConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('object');
         $validator->check($value, $schema, $path, $i, $patternProperties);
 
         $this->addErrors($validator->getErrors());
@@ -170,7 +189,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkType($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new TypeConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('type');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -186,7 +205,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkUndefined($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new UndefinedConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('undefined');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -202,7 +221,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkString($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new StringConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('string');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -218,7 +237,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkNumber($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new NumberConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('number');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -234,7 +253,7 @@ abstract class Constraint implements ConstraintInterface
      */
     protected function checkEnum($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new EnumConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('enum');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());
@@ -242,7 +261,7 @@ abstract class Constraint implements ConstraintInterface
 
     protected function checkFormat($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new FormatConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('format');
         $validator->check($value, $schema, $path, $i);
 
         $this->addErrors($validator->getErrors());

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Constraints;
+
+use JsonSchema\Exception\InvalidArgumentException;
+use JsonSchema\Uri\UriRetriever;
+use JsonSchema\Validator;
+
+/**
+ * Factory for centralize constraint initialization.
+ */
+class Factory
+{
+    /**
+     * @var UriRetriever
+     */
+    protected $uriRetriever;
+
+    /**
+     * @param UriRetriever $uriRetriever
+     */
+    public function __construct(UriRetriever $uriRetriever = null)
+    {
+        if (!$uriRetriever) {
+            $uriRetriever = new UriRetriever();
+        }
+
+        $this->uriRetriever = $uriRetriever;
+    }
+
+    /**
+     * @return UriRetriever
+     */
+    public function getUriRetriever()
+    {
+        return $this->uriRetriever;
+    }
+
+    /**
+     * Create a constraint instance for the given constraint name.
+     *
+     * @param string $constraintName
+     * @return ConstraintInterface|ObjectConstraint
+     * @throws InvalidArgumentException if is not possible create the constraint instance.
+     */
+    public function createInstanceFor($constraintName)
+    {
+        switch ($constraintName) {
+            case 'array':
+            case 'collection':
+                return new CollectionConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'object':
+                return new ObjectConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'type':
+                return new TypeConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'undefined':
+                return new UndefinedConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'string':
+                return new StringConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'number':
+                return new NumberConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'enum':
+                return new EnumConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'format':
+                return new FormatConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'schema':
+                return new SchemaConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            case 'validator':
+                return new Validator(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+        }
+
+        throw new InvalidArgumentException('Unknown constraint ' . $constraintName);
+    }
+}

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -37,7 +37,7 @@ class Validator extends Constraint
      */
     public function check($value, $schema = null, $path = null, $i = null)
     {
-        $validator = new SchemaConstraint($this->checkMode, $this->uriRetriever);
+        $validator = $this->getFactory()->createInstanceFor('schema');
         $validator->check($value, $schema);
 
         $this->addErrors(array_unique($validator->getErrors(), SORT_REGULAR));

--- a/tests/JsonSchema/Tests/Constraints/FactoryTest.php
+++ b/tests/JsonSchema/Tests/Constraints/FactoryTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+use JsonSchema\Constraints\Factory;
+use PHPUnit_Framework_TestCase as TestCase;
+
+class FactoryTest extends TestCase
+{
+    /**
+     * @var Factory
+     */
+    protected $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new Factory();
+    }
+
+    /**
+     * @dataProvider constraintNameProvider
+     *
+     * @param string $constraintName
+     * @param string $expectedClass
+     * @return void
+     */
+    public function testCreateInstanceForConstraintName($constraintName, $expectedClass)
+    {
+        $constraint = $this->factory->createInstanceFor($constraintName);
+
+        $this->assertInstanceOf($expectedClass, $constraint);
+        $this->assertInstanceOf('JsonSchema\Constraints\ConstraintInterface', $constraint);
+        $this->assertSame($this->factory->getUriRetriever(), $constraint->getUriRetriever());
+    }
+
+    public function constraintNameProvider()
+    {
+        return array(
+            array('array', 'JsonSchema\Constraints\CollectionConstraint'),
+            array('collection', 'JsonSchema\Constraints\CollectionConstraint'),
+            array('object', 'JsonSchema\Constraints\ObjectConstraint'),
+            array('type', 'JsonSchema\Constraints\TypeConstraint'),
+            array('undefined', 'JsonSchema\Constraints\UndefinedConstraint'),
+            array('string', 'JsonSchema\Constraints\StringConstraint'),
+            array('number', 'JsonSchema\Constraints\NumberConstraint'),
+            array('enum', 'JsonSchema\Constraints\EnumConstraint'),
+            array('format', 'JsonSchema\Constraints\FormatConstraint'),
+            array('schema', 'JsonSchema\Constraints\SchemaConstraint'),
+            array('validator', 'JsonSchema\Validator'),
+        );
+    }
+
+    /**
+     * @dataProvider invalidConstraintNameProvider
+     *
+     * @param string $constraintName
+     * @return void
+     */
+    public function testExceptionWhenCreateInstanceForInvalidConstraintName($constraintName)
+    {
+        $this->setExpectedException('JsonSchema\Exception\InvalidArgumentException');
+        $this->factory->createInstanceFor($constraintName);
+    }
+
+    public function invalidConstraintNameProvider()
+    {
+        return array(
+            array('invalidConstraintName'),
+        );
+    }
+}


### PR DESCRIPTION
This factory can be injected and allow extend built-in constraint types with custom ones.

This factory allows extend the constraint system with custom ones.

Example:

```php
<?php

class MyFactory extends JsonSchema\Constraints\Factory {
     public function factory($constraintName) {
           if ($constraintName === 'custom_constraint') {
               return new CustomConstraint($this->uriRetriever);
           }

           return super::factory($constraintName);
     }
}

$validator = new Validator(Constraint::CHECK_MODE_NORMAL, null, new MyFactory());
```

This especially usefull when you need extend `FormatConstraint` for to validate custom formats.
