### PR TITLE
Fetching JSON Array from URI

### DIFF
--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -150,7 +150,10 @@ class UriRetriever
 
         // Use the JSON pointer if specified
         $jsonSchema = $this->resolvePointer($jsonSchema, $resolvedUri);
-        $jsonSchema->id = $resolvedUri;
+
+        if ($jsonSchema instanceof \stdClass) {
+            $jsonSchema->id = $resolvedUri;
+        }
 
         return $jsonSchema;
     }

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -287,6 +287,25 @@ JSN
         );
     }
 
+    public function testFetchRefArray()
+    {
+        $retr = new \JsonSchema\Uri\Retrievers\PredefinedArray(
+            array(
+                'http://example.org/array' => <<<JSN
+[1,2,3]
+JSN
+            )
+        );
+
+        $res = new \JsonSchema\RefResolver();
+        $res->getUriRetriever()->setUriRetriever($retr);
+
+        $this->assertEquals(
+            array(1, 2, 3),
+            $res->fetchRef('http://example.org/array', 'http://example.org/array')
+        );
+    }
+
     public function testSetGetUriRetriever()
     {
         $retriever = new \JsonSchema\Uri\UriRetriever;


### PR DESCRIPTION
If you fetch a json array from a URI then a warning is thrown.

This is due to ```JsonSchema\Uri\UriRetriever::retrieve`` attempting to get the 'id' property of the array. 

This pull request contains a simple fix and a test