### PR TITLE
Fix warning on file_get_contents

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -32,8 +32,13 @@ class FileGetContents extends AbstractRetriever
                 'method' => 'GET',
                 'header' => "Accept: " . Validator::SCHEMA_MEDIA_TYPE
             )));
-        
+
+        set_error_handler(function() use ($uri) {
+            throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
+        });
         $response = file_get_contents($uri);
+        restore_error_handler();
+
         if (false === $response) {
             throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
         }

--- a/tests/JsonSchema/Tests/Uri/Fixture/child.json
+++ b/tests/JsonSchema/Tests/Uri/Fixture/child.json
@@ -1,0 +1,11 @@
+{
+  "type":"object",
+  "title":"parent",
+  "properties":
+  {
+    "parentProp":
+    {
+      "type":"boolean"
+    }
+  }
+}

--- a/tests/JsonSchema/Tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/JsonSchema/Tests/Uri/Retrievers/FileGetContentsTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace JsonSchema\Tests\Uri\Retrievers;
+
+use JsonSchema\Uri\Retrievers\FileGetContents;
+
+/**
+ * @group FileGetContents
+ */
+class FileGetContentsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @expectedException JsonSchema\Exception\ResourceNotFoundException
+     */
+    public function testFetchMissingFile()
+    {
+        $res = new FileGetContents();
+        $res->retrieve(__DIR__.'/Fixture/missing.json');
+    }
+
+    public function testFetchFile()
+    {
+        $res = new FileGetContents();
+        $result = $res->retrieve(__DIR__.'/../Fixture/child.json');
+        $this->assertNotEmpty($result);
+    }
+}


### PR DESCRIPTION
Sorry - no test on this. Little bit tricky to write.

If file_get_contents fails then it reports a warning as well as returning false. The code then checks for false and throws an exception. 

This pull request set's a custom error handler (and resets it) that suppresses the warning.

This should be safe to merge with #115.