### PR TITLE
For missing properties, the key for that error in set to ""

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -122,7 +122,7 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError($path, "the property " . $required . " is required");
+                        $this->addError($required, "the property " . $required . " is required");
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {

--- a/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
+++ b/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
@@ -9,8 +9,72 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\Constraints\UndefinedConstraint;
+
 class RequiredPropertyTest extends BaseTestCase
 {
+
+    public function testErrorPropertyIsPopulatedForRequiredIfMissingInInput()
+    {
+        $validator = new UndefinedConstraint();
+        $document = json_decode(
+            '{
+            "bar": 42
+        }'
+        );
+        $schema = json_decode(
+            '{
+            "type": "object",
+            "properties": {
+                "foo": {"type": "number"},
+                "bar": {"type": "number"}
+            },
+            "required": ["foo"]
+        }'
+        );
+
+        $validator->check($document, $schema);
+        $error = $validator->getErrors();
+        $this->assertErrorHasExpectedPropertyValue($error, "foo");
+    }
+
+    public function testErrorPropertyIsPopulatedForRequiredIfEmptyValueInInput()
+    {
+        $validator = new UndefinedConstraint();
+        $document = json_decode(
+            '{
+            "bar": 42,
+            "foo": null
+        }'
+        );
+        $schema = json_decode(
+            '{
+            "type": "object",
+            "properties": {
+                "foo": {"type": "number"},
+                "bar": {"type": "number"}
+            },
+            "required": ["foo"]
+        }'
+        );
+
+        $validator->check($document, $schema);
+        $error = $validator->getErrors();
+        $this->assertErrorHasExpectedPropertyValue($error, "foo");
+    }
+
+    protected function assertErrorHasExpectedPropertyValue($error, $propertyValue)
+    {
+        if (!(isset($error[0]) && is_array($error[0]) && isset($error[0]['property']))) {
+            $this->fail(
+                "Malformed error response. Expected to have subset in form: array(0 => array('property' => <value>)))"
+                . " . Error response was: " . json_encode($error)
+            );
+        }
+        $this->assertEquals($propertyValue, $error[0]['property']);
+
+    }
+
     public function getInvalidTests()
     {
         return array(


### PR DESCRIPTION
Expected bahavior is that the key would be set to the poperty name.

This fix addressed the same issue PR'd by @primitive-type but is
rebased to current master