### PR TITLE
chore(travis): remove phpdoc ext and ignore output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .project
 .settings
 composer.lock
+docs-api

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ install:
 
 script:
   - cd docs && make linkcheck && cd ..
-  - vendor/bin/phpdoc.php -d src -t docs-api
+  - vendor/bin/phpdoc -d src -t docs-api
   - vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This PR fixes a warning when running `phpdoc` on Travis, and ignores the `phpdoc` output.