### PR TITLE
Promote HHVM.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ php:
 matrix:
     allow_failures:
         - php: 7
-        - php: hhvm
 
 install:
   - sudo apt-get -y install pypy python-sphinx graphviz


### PR DESCRIPTION
This repo has a coverage bigger than 85% and tests works with HHVM. This means HHVM support is enough stable for to make it officially supported.