### PR TITLE
Throw exception if max depth exceeded

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema;
 
+use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Uri\Retrievers\UriRetrieverInterface;
 use JsonSchema\Uri\UriRetriever;
 
@@ -96,7 +97,7 @@ class RefResolver
     public function resolve($schema, $sourceUri = null)
     {
         if (self::$depth > self::$maxDepth) {
-            return;
+            throw new JsonDecodingException(JSON_ERROR_DEPTH);
         }
         ++self::$depth;
 

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -334,4 +334,25 @@ JSN
 
         $this->assertEquals($jsonSchema, $resolver->fetchRef($ref, $sourceUri));
     }
+
+    /**
+     * @expectedException \JsonSchema\Exception\JsonDecodingException
+     */
+    public function testMaxDepthExceeded()
+    {
+        // stub schema
+        $jsonSchema = new \stdClass;
+        $jsonSchema->id = 'stub';
+        $jsonSchema->additionalItems = 'stub';
+
+        // mock retriever
+        $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('retrieve'));
+        $retriever->expects($this->any())->method('retrieve')->will($this->returnValue($jsonSchema));
+
+        // stub resolver
+        \JsonSchema\RefResolver::$maxDepth = 0;
+        $resolver = new \JsonSchema\RefResolver($retriever);
+
+        $resolver->resolve($jsonSchema);
+    }
 }


### PR DESCRIPTION
Rather than fail quietly, when the max depth is exceeded, an exception should be thrown. This tells very clearly what's wrong, and you do not spend hours searching for the fault in the schema.