### PR TITLE
Enhancement: Use SVG badge for displaying Travis build status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # JSON Schema for PHP
 
-[![Build Status](https://secure.travis-ci.org/justinrainbow/json-schema.png)](http://travis-ci.org/justinrainbow/json-schema)
+[![Build Status](https://travis-ci.org/justinrainbow/json-schema.svg?branch=master)](https://travis-ci.org/justinrainbow/json-schema)
 [![Latest Stable Version](https://poser.pugx.org/justinrainbow/json-schema/v/stable.png)](https://packagist.org/packages/justinrainbow/json-schema)
 [![Total Downloads](https://poser.pugx.org/justinrainbow/json-schema/downloads.png)](https://packagist.org/packages/justinrainbow/json-schema)
 


### PR DESCRIPTION
This PR

* [x] uses an SVG badge for displaying the Travis build status, as it pleases the eye