### PR TITLE
Fix: Encourage to use phpunit as installed with Composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ if ($validator->isValid()) {
 
 ## Running the tests
 
-    $ phpunit
+    $ vendor/bin/phpunit


### PR DESCRIPTION
This PR

* [x] updates `README.md` and encourages to use `phpunit` as installed with Composer