### PR TITLE
Fix: Constraint::addError() does not return anything

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -63,7 +63,9 @@ class TypeConstraint extends Constraint
             }
 
             if (!$validatedOneType) {
-                return $this->addErrors($errors);
+                $this->addErrors($errors);
+
+                return;
             }
         } elseif (is_object($type)) {
             $this->checkUndefined($value, $type, $path);


### PR DESCRIPTION
This PR

* [x] calls a method, then returns, rather than attempting to return the result of a method which does not return anything