### PR TITLE
Enhancement: Speed up builds as much as possible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
 
 install:
   - sudo apt-get -y install pypy python-sphinx graphviz
-  - travis_retry composer update --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-source
 
 script:
   - cd docs && make linkcheck && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ php:
   - hhvm
 
 matrix:
+  fast_finish: true
   allow_failures:
     - php: 7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: php
 
-php:
-  - 5.3.3
-  - 5.3
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7
-  - hhvm
-
 matrix:
   fast_finish: true
+  include:
+    - php: 5.3.3
+    - php: 5.3
+    - php: 5.4
+    - php: 5.5
+    - php: 5.6
+    - php: 7
+    - php: hhvm
   allow_failures:
     - php: 7
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,11 @@ matrix:
   allow_failures:
     - php: 7
 
+before_install:
+  - composer selfupdate
+
 install:
   - sudo apt-get -y install pypy python-sphinx graphviz
-  - composer selfupdate
   - travis_retry composer update --no-interaction --prefer-source
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
+      env: CHECK_LINKS=true
     - php: 7
     - php: hhvm
   allow_failures:
@@ -17,10 +18,10 @@ before_install:
   - composer selfupdate
 
 install:
-  - sudo apt-get -y install pypy python-sphinx graphviz
+  - if [[ "$CHECK_LINKS" == "true" ]]; then sudo apt-get -y install pypy python-sphinx graphviz; fi
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - cd docs && make linkcheck && cd ..
+  - if [[ "$CHECK_LINKS" == "true" ]]; then cd docs && make linkcheck && cd ..; fi
   - vendor/bin/phpdoc -d src -t docs-api
   - vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,10 @@ php:
   - 5.6
   - 7
   - hhvm
- 
+
 matrix:
-    allow_failures:
-        - php: 7
+  allow_failures:
+    - php: 7
 
 install:
   - sudo apt-get -y install pypy python-sphinx graphviz

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ before_install:
   - composer selfupdate
 
 install:
-  - if [[ "$CHECK_LINKS" == "true" ]]; then sudo apt-get -y install pypy python-sphinx graphviz; fi
   - travis_retry composer install --no-interaction --prefer-source
+  - if [[ "$CHECK_LINKS" == "true" ]]; then sudo apt-get -y install pypy python-sphinx graphviz; fi
 
 script:
+  - vendor/bin/phpunit --coverage-text
   - if [[ "$CHECK_LINKS" == "true" ]]; then cd docs && make linkcheck && cd ..; fi
   - if [[ "$BUILD_DOCS" == "true" ]]; then vendor/bin/phpdoc -d src -t docs-api; fi
-  - vendor/bin/phpunit --coverage-text

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
-      env: CHECK_LINKS=true
+      env: CHECK_LINKS=true BUILD_DOCS=true
     - php: 7
     - php: hhvm
   allow_failures:
@@ -23,5 +23,5 @@ install:
 
 script:
   - if [[ "$CHECK_LINKS" == "true" ]]; then cd docs && make linkcheck && cd ..; fi
-  - vendor/bin/phpdoc -d src -t docs-api
+  - if [[ "$BUILD_DOCS" == "true" ]]; then vendor/bin/phpdoc -d src -t docs-api; fi
   - vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This PR

* [x] indents `.travis.yml` consistently (unrelated)
* [x] provides feedback quickly if it has failed, using the `fast_finish` option
* [x] moves update of Composer itself to `before_install` section (unrelated)
* [x] runs `composer install` instead of `composer update` (unrelated)
* [x] checks links on PHP 5.6 only 
* [x] builds docs on PHP 5.6 only

### Before

<img width="1067" alt="screen shot 2015-07-12 at 23 25 43" src="https://cloud.githubusercontent.com/assets/605483/8642102/61ec76d4-28ed-11e5-8eaf-d5ef037b1f6f.png">

See https://travis-ci.org/justinrainbow/json-schema/builds/70676013.

### After

<img width="1067" alt="screen shot 2015-07-13 at 00 09 41" src="https://cloud.githubusercontent.com/assets/605483/8642536/825d68b4-28f3-11e5-8696-455aca79630a.png">

https://travis-ci.org/justinrainbow/json-schema/builds/70680917.