### PR TITLE
Fix: Start all messages with a capital letter

### DIFF
--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -41,6 +41,6 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, "does not have a value in the enumeration " . print_r($schema->enum, true));
+        $this->addError($path, "Does not have a value in the enumeration " . print_r($schema->enum, true));
     }
 }

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -26,40 +26,40 @@ class NumberConstraint extends Constraint
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element === $schema->minimum) {
-                    $this->addError($path, "must have a minimum value greater than boundary value of " . $schema->minimum);
+                    $this->addError($path, "Must have a minimum value greater than boundary value of " . $schema->minimum);
                 } else if ($element < $schema->minimum) {
-                    $this->addError($path, "must have a minimum value of " . $schema->minimum);
+                    $this->addError($path, "Must have a minimum value of " . $schema->minimum);
                 }
             } else {
-                $this->addError($path, "use of exclusiveMinimum requires presence of minimum");
+                $this->addError($path, "Use of exclusiveMinimum requires presence of minimum");
             }
         } else if (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError($path, "must have a minimum value of " . $schema->minimum);
+            $this->addError($path, "Must have a minimum value of " . $schema->minimum);
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element === $schema->maximum) {
-                    $this->addError($path, "must have a maximum value less than boundary value of " . $schema->maximum);
+                    $this->addError($path, "Must have a maximum value less than boundary value of " . $schema->maximum);
                 } else if ($element > $schema->maximum) {
-                    $this->addError($path, "must have a maximum value of " . $schema->maximum);
+                    $this->addError($path, "Must have a maximum value of " . $schema->maximum);
                 }
             } else {
-                $this->addError($path, "use of exclusiveMaximum requires presence of maximum");
+                $this->addError($path, "Use of exclusiveMaximum requires presence of maximum");
             }
         } else if (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError($path, "must have a maximum value of " . $schema->maximum);
+            $this->addError($path, "Must have a maximum value of " . $schema->maximum);
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError($path, "is not divisible by " . $schema->divisibleBy);
+            $this->addError($path, "Is not divisible by " . $schema->divisibleBy);
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError($path, "must be a multiple of " . $schema->multipleOf);
+            $this->addError($path, "Must be a multiple of " . $schema->multipleOf);
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -92,7 +92,7 @@ class ObjectConstraint extends Constraint
             // property requires presence of another
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
-                $this->addError($path, "the presence of the property " . $i . " requires that " . $require . " also be present");
+                $this->addError($path, "The presence of the property " . $i . " requires that " . $require . " also be present");
             }
 
             if (!$definition) {

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -24,17 +24,17 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError($path, "must be at most " . $schema->maxLength . " characters long");
+            $this->addError($path, "Must be at most " . $schema->maxLength . " characters long");
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError($path, "must be at least " . $schema->minLength . " characters long");
+            $this->addError($path, "Must be at least " . $schema->minLength . " characters long");
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
-            $this->addError($path, "does not match the regex pattern " . $schema->pattern);
+            $this->addError($path, "Does not match the regex pattern " . $schema->pattern);
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -122,13 +122,13 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError($required, "the property " . $required . " is required");
+                        $this->addError($required, "The property " . $required . " is required");
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ( $schema->required && $value instanceof UndefinedConstraint) {
-                    $this->addError($path, "is missing and it is required");
+                    $this->addError($path, "Is missing and it is required");
                 }
             }
         }
@@ -148,7 +148,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised it must be a disallowed value
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "disallowed value was matched");
+                $this->addError($path, "Disallowed value was matched");
             } else {
                 $this->errors = $initErrors;
             }
@@ -160,7 +160,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised then the instance validated against the "not" schema
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "matched a schema which it should not");
+                $this->addError($path, "Matched a schema which it should not");
             } else {
                 $this->errors = $initErrors;
             }
@@ -170,12 +170,12 @@ class UndefinedConstraint extends Constraint
         if (is_object($value)) {
             if (isset($schema->minProperties)) {
                 if (count(get_object_vars($value)) < $schema->minProperties) {
-                    $this->addError($path, "must contain a minimum of " . $schema->minProperties . " properties");
+                    $this->addError($path, "Must contain a minimum of " . $schema->minProperties . " properties");
                 }
             }
             if (isset($schema->maxProperties)) {
                 if (count(get_object_vars($value)) > $schema->maxProperties) {
-                    $this->addError($path, "must contain no more than " . $schema->maxProperties . " properties");
+                    $this->addError($path, "Must contain no more than " . $schema->maxProperties . " properties");
                 }
             }
         }
@@ -209,7 +209,7 @@ class UndefinedConstraint extends Constraint
                 $isValid = $isValid && (count($this->getErrors()) == count($initErrors));
             }
             if (!$isValid) {
-                $this->addError($path, "failed to match all schemas");
+                $this->addError($path, "Failed to match all schemas");
             }
         }
 
@@ -224,7 +224,7 @@ class UndefinedConstraint extends Constraint
                 }
             }
             if (!$isValid) {
-                $this->addError($path, "failed to match at least one schema");
+                $this->addError($path, "Failed to match at least one schema");
             } else {
                 $this->errors = $startErrors;
             }


### PR DESCRIPTION
This PR

* [x] starts all messages with a capital letter

:information_desk_person: Some messages already do, others don't - it's just an opinion, but I feel it should be consistent. What do you think?