### PR TITLE
Fix: Consistently create error messages

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -24,12 +24,18 @@ class CollectionConstraint extends Constraint
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
-            $this->addError($path, "There must be a minimum of " . $schema->minItems . " items in the array");
+            $this->addError($path, sprintf(
+                "There must be a minimum of %s items in the array",
+                $schema->minItems
+            ));
         }
 
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
-            $this->addError($path, "There must be a maximum of " . $schema->maxItems . " items in the array");
+            $this->addError($path, sprintf(
+                "There must be a maximum of %s items in the array",
+                $schema->maxItems
+            ));
         }
 
         // Verify uniqueItems
@@ -91,8 +97,11 @@ class CollectionConstraint extends Constraint
                         if ($schema->additionalItems !== false) {
                             $this->checkUndefined($v, $schema->additionalItems, $path, $k);
                         } else {
-                            $this->addError(
-                                $path, 'The item ' . $i . '[' . $k . '] is not defined and the definition does not allow additional items');
+                            $this->addError($path, sprintf(
+                                'The item %s[%s] is not defined and the definition does not allow additional items',
+                                $i,
+                                $k
+                            ));
                         }
                     } else {
                         // Should be valid against an empty schema

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -25,7 +25,7 @@ class CollectionConstraint extends Constraint
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
             $this->addError($path, sprintf(
-                "There must be a minimum of %s items in the array",
+                'There must be a minimum of %s items in the array',
                 $schema->minItems
             ));
         }
@@ -33,7 +33,7 @@ class CollectionConstraint extends Constraint
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
             $this->addError($path, sprintf(
-                "There must be a maximum of %s items in the array",
+                'There must be a maximum of %s items in the array',
                 $schema->maxItems
             ));
         }
@@ -45,7 +45,7 @@ class CollectionConstraint extends Constraint
                 $unique = array_map(function($e) { return var_export($e, true); }, $value);
             }
             if (count(array_unique($unique)) != count($value)) {
-                $this->addError($path, "There are no duplicates allowed in the array");
+                $this->addError($path, 'There are no duplicates allowed in the array');
             }
         }
 

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -42,7 +42,7 @@ class EnumConstraint extends Constraint
         }
 
         $this->addError($path, sprintf(
-            "Does not have a value in the enumeration %s",
+            'Does not have a value in the enumeration %s',
             print_r($schema->enum, true)
         ));
     }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -41,6 +41,9 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, "Does not have a value in the enumeration " . print_r($schema->enum, true));
+        $this->addError($path, sprintf(
+            "Does not have a value in the enumeration %s",
+            print_r($schema->enum, true)
+        ));
     }
 }

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -78,51 +78,51 @@ class FormatConstraint extends Constraint
 
             case 'color':
                 if (!$this->validateColor($element)) {
-                    $this->addError($path, "Invalid color");
+                    $this->addError($path, 'Invalid color');
                 }
                 break;
 
             case 'style':
                 if (!$this->validateStyle($element)) {
-                    $this->addError($path, "Invalid style");
+                    $this->addError($path, 'Invalid style');
                 }
                 break;
 
             case 'phone':
                 if (!$this->validatePhone($element)) {
-                    $this->addError($path, "Invalid phone number");
+                    $this->addError($path, 'Invalid phone number');
                 }
                 break;
 
             case 'uri':
                 if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError($path, "Invalid URL format");
+                    $this->addError($path, 'Invalid URL format');
                 }
                 break;
 
             case 'email':
                 if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError($path, "Invalid email");
+                    $this->addError($path, 'Invalid email');
                 }
                 break;
 
             case 'ip-address':
             case 'ipv4':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)) {
-                    $this->addError($path, "Invalid IP address");
+                    $this->addError($path, 'Invalid IP address');
                 }
                 break;
 
             case 'ipv6':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV6)) {
-                    $this->addError($path, "Invalid IP address");
+                    $this->addError($path, 'Invalid IP address');
                 }
                 break;
 
             case 'host-name':
             case 'hostname':
                 if (!$this->validateHostname($element)) {
-                    $this->addError($path, "Invalid hostname");
+                    $this->addError($path, 'Invalid hostname');
                 }
                 break;
 

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -29,13 +29,19 @@ class FormatConstraint extends Constraint
         switch ($schema->format) {
             case 'date':
                 if (!$date = $this->validateDateTime($element, 'Y-m-d')) {
-                    $this->addError($path, sprintf('Invalid date %s, expected format YYYY-MM-DD', json_encode($element)));
+                    $this->addError($path, sprintf(
+                        'Invalid date %s, expected format YYYY-MM-DD', 
+                        json_encode($element)
+                    ));
                 }
                 break;
 
             case 'time':
                 if (!$this->validateDateTime($element, 'H:i:s')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected format hh:mm:ss', json_encode($element)));
+                    $this->addError($path, sprintf(
+                        'Invalid time %s, expected format hh:mm:ss', 
+                        json_encode($element)
+                    ));
                 }
                 break;
 
@@ -45,19 +51,28 @@ class FormatConstraint extends Constraint
                     !$this->validateDateTime($element, 'Y-m-d\TH:i:sP') &&
                     !$this->validateDateTime($element, 'Y-m-d\TH:i:sO')
                 ) {
-                    $this->addError($path, sprintf('Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm', json_encode($element)));
+                    $this->addError($path, sprintf(
+                        'Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm', 
+                        json_encode($element)
+                    ));
                 }
                 break;
 
             case 'utc-millisec':
                 if (!$this->validateDateTime($element, 'U')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected integer of milliseconds since Epoch', json_encode($element)));
+                    $this->addError($path, sprintf(
+                        'Invalid time %s, expected integer of milliseconds since Epoch', 
+                        json_encode($element)
+                    ));
                 }
                 break;
 
             case 'regex':
                 if (!$this->validateRegex($element)) {
-                    $this->addError($path, 'Invalid regex format ' . $element);
+                    $this->addError($path, sprintf(
+                        'Invalid regex format %s', 
+                        $element
+                    ));
                 }
                 break;
 

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -26,40 +26,64 @@ class NumberConstraint extends Constraint
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element === $schema->minimum) {
-                    $this->addError($path, "Must have a minimum value greater than boundary value of " . $schema->minimum);
+                    $this->addError($path, sprintf(
+                        "Must have a minimum value greater than boundary value of %s", 
+                        $schema->minimum
+                    ));
                 } else if ($element < $schema->minimum) {
-                    $this->addError($path, "Must have a minimum value of " . $schema->minimum);
+                    $this->addError($path, sprintf(
+                        "Must have a minimum value of %s", 
+                        $schema->minimum
+                    ));
                 }
             } else {
                 $this->addError($path, "Use of exclusiveMinimum requires presence of minimum");
             }
         } else if (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError($path, "Must have a minimum value of " . $schema->minimum);
+            $this->addError($path, sprintf(
+                "Must have a minimum value of %s", 
+                $schema->minimum
+            ));
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element === $schema->maximum) {
-                    $this->addError($path, "Must have a maximum value less than boundary value of " . $schema->maximum);
+                    $this->addError($path, sprintf(
+                        "Must have a maximum value less than boundary value of %s", 
+                        $schema->maximum
+                    ));
                 } else if ($element > $schema->maximum) {
-                    $this->addError($path, "Must have a maximum value of " . $schema->maximum);
+                    $this->addError($path, sprintf(
+                        "Must have a maximum value of %s", 
+                        $schema->maximum
+                    ));
                 }
             } else {
                 $this->addError($path, "Use of exclusiveMaximum requires presence of maximum");
             }
         } else if (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError($path, "Must have a maximum value of " . $schema->maximum);
+            $this->addError($path, sprintf(
+                "Must have a maximum value of %s", 
+                $schema->maximum
+            ));
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError($path, "Is not divisible by " . $schema->divisibleBy);
+            $this->addError($path, sprintf(
+                "Is not divisible by %s", 
+                $schema->divisibleBy
+            ));
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError($path, "Must be a multiple of " . $schema->multipleOf);
+            $this->addError($path, sprintf(
+                "Must be a multiple of %s", 
+                $schema->multipleOf
+            ));
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -27,21 +27,21 @@ class NumberConstraint extends Constraint
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element === $schema->minimum) {
                     $this->addError($path, sprintf(
-                        "Must have a minimum value greater than boundary value of %s", 
+                        'Must have a minimum value greater than boundary value of %s', 
                         $schema->minimum
                     ));
                 } else if ($element < $schema->minimum) {
                     $this->addError($path, sprintf(
-                        "Must have a minimum value of %s", 
+                        'Must have a minimum value of %s', 
                         $schema->minimum
                     ));
                 }
             } else {
-                $this->addError($path, "Use of exclusiveMinimum requires presence of minimum");
+                $this->addError($path, 'Use of exclusiveMinimum requires presence of minimum');
             }
         } else if (isset($schema->minimum) && $element < $schema->minimum) {
             $this->addError($path, sprintf(
-                "Must have a minimum value of %s", 
+                'Must have a minimum value of %s', 
                 $schema->minimum
             ));
         }
@@ -51,21 +51,21 @@ class NumberConstraint extends Constraint
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element === $schema->maximum) {
                     $this->addError($path, sprintf(
-                        "Must have a maximum value less than boundary value of %s", 
+                        'Must have a maximum value less than boundary value of %s', 
                         $schema->maximum
                     ));
                 } else if ($element > $schema->maximum) {
                     $this->addError($path, sprintf(
-                        "Must have a maximum value of %s", 
+                        'Must have a maximum value of %s', 
                         $schema->maximum
                     ));
                 }
             } else {
-                $this->addError($path, "Use of exclusiveMaximum requires presence of maximum");
+                $this->addError($path, 'Use of exclusiveMaximum requires presence of maximum');
             }
         } else if (isset($schema->maximum) && $element > $schema->maximum) {
             $this->addError($path, sprintf(
-                "Must have a maximum value of %s", 
+                'Must have a maximum value of %s', 
                 $schema->maximum
             ));
         }
@@ -73,7 +73,7 @@ class NumberConstraint extends Constraint
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
             $this->addError($path, sprintf(
-                "Is not divisible by %s", 
+                'Is not divisible by %s', 
                 $schema->divisibleBy
             ));
         }
@@ -81,7 +81,7 @@ class NumberConstraint extends Constraint
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
             $this->addError($path, sprintf(
-                "Must be a multiple of %s", 
+                'Must be a multiple of %s', 
                 $schema->multipleOf
             ));
         }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -46,7 +46,10 @@ class ObjectConstraint extends Constraint
         foreach ($patternProperties as $pregex => $schema) {
             // Validate the pattern before using it to test for matches
             if (@preg_match('/'. $pregex . '/', '') === false) {
-                $this->addError($path, 'The pattern "' . $pregex . '" is invalid');
+                $this->addError($path, sprintf(
+                    'The pattern "%s" is invalid',
+                    $pregex
+                ));
                 continue;
             }
             foreach ($element as $i => $value) {
@@ -77,7 +80,10 @@ class ObjectConstraint extends Constraint
 
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
-                $this->addError($path, "The property - " . $i . " - is not defined and the definition does not allow additional properties");
+                $this->addError($path, sprintf(
+                    "The property - %s - is not defined and the definition does not allow additional properties",
+                    $i
+                ));
             }
 
             // additional properties defined
@@ -92,7 +98,11 @@ class ObjectConstraint extends Constraint
             // property requires presence of another
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
-                $this->addError($path, "The presence of the property " . $i . " requires that " . $require . " also be present");
+                $this->addError($path, sprintf(
+                    "The presence of the property %s requires that %s also be present",
+                    $i,
+                    $require
+                ));
             }
 
             if (!$definition) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -81,7 +81,7 @@ class ObjectConstraint extends Constraint
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
                 $this->addError($path, sprintf(
-                    "The property - %s - is not defined and the definition does not allow additional properties",
+                    'The property - %s - is not defined and the definition does not allow additional properties',
                     $i
                 ));
             }
@@ -99,7 +99,7 @@ class ObjectConstraint extends Constraint
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
                 $this->addError($path, sprintf(
-                    "The presence of the property %s requires that %s also be present",
+                    'The presence of the property %s requires that %s also be present',
                     $i,
                     $require
                 ));

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -25,7 +25,7 @@ class StringConstraint extends Constraint
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
             $this->addError($path, sprintf(
-                "Must be at most %s characters long",
+                'Must be at most %s characters long',
                 $schema->maxLength
             ));
         }
@@ -33,7 +33,7 @@ class StringConstraint extends Constraint
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
             $this->addError($path, sprintf(
-                "Must be at least %s characters long",
+                'Must be at least %s characters long',
                 $schema->minLength
             ));
         }
@@ -41,7 +41,7 @@ class StringConstraint extends Constraint
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
             $this->addError($path, sprintf(
-                "Does not match the regex pattern %s",
+                'Does not match the regex pattern %s',
                 $schema->pattern
             ));
         }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -24,17 +24,26 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError($path, "Must be at most " . $schema->maxLength . " characters long");
+            $this->addError($path, sprintf(
+                "Must be at most %s characters long",
+                $schema->maxLength
+            ));
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError($path, "Must be at least " . $schema->minLength . " characters long");
+            $this->addError($path, sprintf(
+                "Must be at least %s characters long",
+                $schema->minLength
+            ));
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
-            $this->addError($path, "Does not match the regex pattern " . $schema->pattern);
+            $this->addError($path, sprintf(
+                "Does not match the regex pattern %s",
+                $schema->pattern
+            ));
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -83,7 +83,7 @@ class TypeConstraint extends Constraint
                 );
             }
             $this->addError($path, sprintf(
-                "%s value found, but %s is required",
+                '%s value found, but %s is required',
                 gettype($value),
                 self::$wording[$type]
             ));

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -82,7 +82,11 @@ class TypeConstraint extends Constraint
                         implode(', ', array_filter(self::$wording)))
                 );
             }
-            $this->addError($path, gettype($value) . " value found, but " . self::$wording[$type] . " is required");
+            $this->addError($path, sprintf(
+                "%s value found, but %s is required",
+                gettype($value),
+                self::$wording[$type]
+            ));
         }
     }
 

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -123,7 +123,7 @@ class UndefinedConstraint extends Constraint
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
                         $this->addError($required, sprintf(
-                            "The property %s is required",
+                            'The property %s is required',
                             $required
                         ));
                     }
@@ -131,7 +131,7 @@ class UndefinedConstraint extends Constraint
             } else if (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ( $schema->required && $value instanceof UndefinedConstraint) {
-                    $this->addError($path, "Is missing and it is required");
+                    $this->addError($path, 'Is missing and it is required');
                 }
             }
         }
@@ -151,7 +151,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised it must be a disallowed value
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "Disallowed value was matched");
+                $this->addError($path, 'Disallowed value was matched');
             } else {
                 $this->errors = $initErrors;
             }
@@ -163,7 +163,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised then the instance validated against the "not" schema
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "Matched a schema which it should not");
+                $this->addError($path, 'Matched a schema which it should not');
             } else {
                 $this->errors = $initErrors;
             }
@@ -174,7 +174,7 @@ class UndefinedConstraint extends Constraint
             if (isset($schema->minProperties)) {
                 if (count(get_object_vars($value)) < $schema->minProperties) {
                     $this->addError($path, sprintf(
-                        "Must contain a minimum of % properties",
+                        'Must contain a minimum of % properties',
                         $schema->minProperties
                     ));
                 }
@@ -182,7 +182,7 @@ class UndefinedConstraint extends Constraint
             if (isset($schema->maxProperties)) {
                 if (count(get_object_vars($value)) > $schema->maxProperties) {
                     $this->addError($path, sprintf(
-                        "Must contain no more than %s properties",
+                        'Must contain no more than %s properties',
                         $schema->maxProperties
                     ));
                 }
@@ -218,7 +218,7 @@ class UndefinedConstraint extends Constraint
                 $isValid = $isValid && (count($this->getErrors()) == count($initErrors));
             }
             if (!$isValid) {
-                $this->addError($path, "Failed to match all schemas");
+                $this->addError($path, 'Failed to match all schemas');
             }
         }
 
@@ -233,7 +233,7 @@ class UndefinedConstraint extends Constraint
                 }
             }
             if (!$isValid) {
-                $this->addError($path, "Failed to match at least one schema");
+                $this->addError($path, 'Failed to match at least one schema');
             } else {
                 $this->errors = $startErrors;
             }
@@ -284,7 +284,7 @@ class UndefinedConstraint extends Constraint
                     // Draft 3 string is allowed - e.g. "dependencies": {"bar": "foo"}
                     if (!property_exists($value, $dependency)) {
                         $this->addError($path, sprintf(
-                            "%s depends on %s and %s is missing",
+                            '%s depends on %s and %s is missing',
                             $key,
                             $dependency,
                             $dependency
@@ -295,7 +295,7 @@ class UndefinedConstraint extends Constraint
                     foreach ($dependency as $d) {
                         if (!property_exists($value, $d)) {
                             $this->addError($path, sprintf(
-                                "%s depends on %s and %s is missing",
+                                '%s depends on %s and %s is missing',
                                 $key,
                                 $d,
                                 $d

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -122,7 +122,10 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError($required, "The property " . $required . " is required");
+                        $this->addError($required, sprintf(
+                            "The property %s is required",
+                            $required
+                        ));
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {
@@ -170,12 +173,18 @@ class UndefinedConstraint extends Constraint
         if (is_object($value)) {
             if (isset($schema->minProperties)) {
                 if (count(get_object_vars($value)) < $schema->minProperties) {
-                    $this->addError($path, "Must contain a minimum of " . $schema->minProperties . " properties");
+                    $this->addError($path, sprintf(
+                        "Must contain a minimum of % properties",
+                        $schema->minProperties
+                    ));
                 }
             }
             if (isset($schema->maxProperties)) {
                 if (count(get_object_vars($value)) > $schema->maxProperties) {
-                    $this->addError($path, "Must contain no more than " . $schema->maxProperties . " properties");
+                    $this->addError($path, sprintf(
+                        "Must contain no more than %s properties",
+                        $schema->maxProperties
+                    ));
                 }
             }
         }
@@ -274,13 +283,23 @@ class UndefinedConstraint extends Constraint
                 if (is_string($dependency)) {
                     // Draft 3 string is allowed - e.g. "dependencies": {"bar": "foo"}
                     if (!property_exists($value, $dependency)) {
-                        $this->addError($path, "$key depends on $dependency and $dependency is missing");
+                        $this->addError($path, sprintf(
+                            "%s depends on %s and %s is missing",
+                            $key,
+                            $dependency,
+                            $dependency
+                        ));
                     }
                 } else if (is_array($dependency)) {
                     // Draft 4 must be an array - e.g. "dependencies": {"bar": ["foo"]}
                     foreach ($dependency as $d) {
                         if (!property_exists($value, $d)) {
-                            $this->addError($path, "$key depends on $d and $d is missing");
+                            $this->addError($path, sprintf(
+                                "%s depends on %s and %s is missing",
+                                $key,
+                                $d,
+                                $d
+                            ));
                         }
                     }
                 } else if (is_object($dependency)) {


### PR DESCRIPTION
This PR

* [x] consistently uses `sprintf()` for creating error messages
* [x] consistently uses single quotes instead of double quotes for error messages

Follows https://github.com/justinrainbow/json-schema/pull/170#issuecomment-121040946.