### PR TITLE
Fix path output for required properties

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -121,11 +121,7 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-<<<<<<< HEAD
-                        $this->addError($required, "The property " . $required . " is required", 'required');
-=======
                         $this->addError((!$path) ? $required : "$path.$required", "The property " . $required . " is required", 'required');
->>>>>>> 9bda789... add variable path
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {


### PR DESCRIPTION
Example:

Before:
   `day: "The property day is required"`
After
   `availability[0].hours[0].day: "The property day is required"`