### PR TITLE
Change to allow MaxDepth to be set on construct of the RefResolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ $schema = $retriever->retrieve('file://' . realpath('schema.json'));
 $data = json_decode(file_get_contents('data.json'));
 
 // If you use $ref or if you are unsure, resolve those references here
-// This modifies the $schema object
+// This modifies the $schema object, if the schema has a max depth greater than 7 
+// you can pass as an additional value in the RefResolver
 $refResolver = new JsonSchema\RefResolver($retriever);
 $refResolver->resolve($schema, 'file://' . __DIR__);
 

--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -48,7 +48,10 @@ class RefResolver
     public function __construct($retriever = null, $maxDepth = 7)
     {
         $this->uriRetriever = $retriever;
-        self::$maxDepth = $maxDepth;
+
+        if (null === self::$maxDepth) {
+            self::$maxDepth = $maxDepth;
+        }
     }
 
     /**

--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -34,7 +34,7 @@ class RefResolver
      * maximum references depth
      * @var integer
      */
-    public static $maxDepth = 7;
+    public static $maxDepth;
 
     /**
      * @var UriRetrieverInterface
@@ -43,10 +43,12 @@ class RefResolver
 
     /**
      * @param UriRetriever $retriever
+     * @param int $maxDepth
      */
-    public function __construct($retriever = null)
+    public function __construct($retriever = null, $maxDepth = 7)
     {
         $this->uriRetriever = $retriever;
+        self::$maxDepth = $maxDepth;
     }
 
     /**

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -349,7 +349,9 @@ JSN
         $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('retrieve'));
         $retriever->expects($this->any())->method('retrieve')->will($this->returnValue($jsonSchema));
 
-        $resolver = new \JsonSchema\RefResolver($retriever, 0);
+        // stub resolver
+        \JsonSchema\RefResolver::$maxDepth = 0;
+        $resolver = new \JsonSchema\RefResolver($retriever);
 
         $resolver->resolve($jsonSchema);
     }

--- a/tests/JsonSchema/Tests/RefResolverTest.php
+++ b/tests/JsonSchema/Tests/RefResolverTest.php
@@ -349,9 +349,7 @@ JSN
         $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('retrieve'));
         $retriever->expects($this->any())->method('retrieve')->will($this->returnValue($jsonSchema));
 
-        // stub resolver
-        \JsonSchema\RefResolver::$maxDepth = 0;
-        $resolver = new \JsonSchema\RefResolver($retriever);
+        $resolver = new \JsonSchema\RefResolver($retriever, 0);
 
         $resolver->resolve($jsonSchema);
     }


### PR DESCRIPTION
If required for complex schemas the ability to set the max depth on construct of the RefResolver

No B/C break.