### PR TITLE
Fix #93 ($ref to local definition not working)

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/BaseTestCase.php
+++ b/tests/JsonSchema/Tests/Constraints/BaseTestCase.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\RefResolver;
+use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
 
 abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
@@ -18,9 +20,14 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
      */
     public function testInvalidCases($input, $schema, $checkMode = Validator::CHECK_MODE_NORMAL, $errors = array())
     {
+        $schema = json_decode($schema);
+
+        $refResolver = new RefResolver(new UriRetriever);
+        $refResolver->resolve($schema);
+
         $validator = new Validator($checkMode);
 
-        $validator->check(json_decode($input), json_decode($schema));
+        $validator->check(json_decode($input), $schema);
 
         if (array() !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(),true));
@@ -33,9 +40,14 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
      */
     public function testValidCases($input, $schema, $checkMode = Validator::CHECK_MODE_NORMAL)
     {
+        $schema = json_decode($schema);
+
+        $refResolver = new RefResolver(new UriRetriever);
+        $refResolver->resolve($schema);
+
         $validator = new Validator($checkMode);
 
-        $validator->check(json_decode($input), json_decode($schema));
+        $validator->check(json_decode($input), $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 

--- a/tests/JsonSchema/Tests/Drafts/Draft4Test.php
+++ b/tests/JsonSchema/Tests/Drafts/Draft4Test.php
@@ -18,7 +18,7 @@ class Draft4Test extends BaseDraftTestCase
             // Not Yet Implemented
             'definitions.json',
             // Partially Implemented
-            //'ref.json',
+            'ref.json',
             'refRemote.json',
             // Optional
             'bignum.json',

--- a/tests/JsonSchema/Tests/Drafts/Draft4Test.php
+++ b/tests/JsonSchema/Tests/Drafts/Draft4Test.php
@@ -18,7 +18,7 @@ class Draft4Test extends BaseDraftTestCase
             // Not Yet Implemented
             'definitions.json',
             // Partially Implemented
-            'ref.json',
+            //'ref.json',
             'refRemote.json',
             // Optional
             'bignum.json',


### PR DESCRIPTION
Another attempt at getting issue #93 sorted - thanks to @co3k and @stoiev for putting in the initial leg work.  Based my initial work on #119, but actually got the tests running properly with the resolver too and the official test pack.  This reduces the 8 failures mentioned by @bighappyface in #119 down to 3.

I'm not sure this is quite the right way to fix it from an architectural point of view, but it does improve the capability of this library, at least.

In order to get the remaining 3 failing tests to pass, I suspect there will need to be a fairly big rewrite.  The main problem is around that of recursion - self-referencing documents will simply cause the current design to fail.  But that should be the subject of another issue.