### PR TITLE
#181 make RefSolver::$maxDepth able to configure

### DIFF
--- a/src/JsonSchema/RefResolver.php
+++ b/src/JsonSchema/RefResolver.php
@@ -226,4 +226,9 @@ class RefResolver
 
         return $this;
     }
+
+    public function setMaxDepth($maxDepth)
+    {
+        self::$maxDepth = $maxDepth;
+    }
 }


### PR DESCRIPTION
I am having this #184 issue also. Due to low maxDepth, `JsonSchema\Exception\JsonDecodingException: The maximum stack depth has been exceeded` message is keep throwing.

Make it changeable so that it can be changed based on developer needs.