### PR TITLE
Fix additional properties validation

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -65,7 +65,7 @@ class UndefinedConstraint extends Constraint
         }
 
         // check object
-        if (is_object($value) && (isset($schema->properties) || isset($schema->patternProperties))) {
+        if (is_object($value) && (isset($schema->properties) || isset($schema->patternProperties) || isset($schema->additionalProperties))) {
             $this->checkObject(
                 $value,
                 isset($schema->properties) ? $schema->properties : null,

--- a/tests/JsonSchema/Tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/AdditionalPropertiesTest.php
@@ -80,7 +80,29 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "additionalProperties": {"type":"string"}
                 }',
                 Validator::CHECK_MODE_TYPE_CAST
-            )
+            ),
+            array(
+                '{
+                  "prop1": "a",
+                  "prop2": "b"
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "boolean"
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "prop1": "a",
+                  "prop2": "b"
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": false
+                }'
+            ),
         );
     }
 
@@ -137,7 +159,29 @@ class AdditionalPropertiesTest extends BaseTestCase
                   },
                   "additionalProperties": true
                 }'
-            )
+            ),
+            array(
+                '{
+                  "prop1": "a",
+                  "prop2": "b"
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "prop1": "a",
+                  "prop2": "b"
+                }',
+                '{
+                  "type": "object",
+                  "additionalProperties": true
+                }'
+            ),
         );
     }
 }


### PR DESCRIPTION
This fixes error when `additionalProperties` is ignored if `properties` or `patternProperties` is not set.
Such definitions are used in http://json-schema.org/draft-04/schema