### PR TITLE
add oneOf object type tests – one of them fails

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/OfPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/OfPropertiesTest.php
@@ -50,6 +50,58 @@ class OfPropertiesTest extends BaseTestCase
                   "required": ["prop1"]
                 }'
             ),
+            array(
+                '{"prop1": "abc", "prop2": { "nested": true }}',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "prop1": {"type": "string"},
+                    "prop2": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "nested": {"type": "boolean"}
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "nested": {"type": "string"}
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["prop1"]
+                }'
+            ),
+            array(
+                '{"prop1": "abc", "prop2": { "another": "asdf" }}',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "prop1": {"type": "string"},
+                    "prop2": {
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "nested": {"type": "boolean"}
+                          }
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "another": {"type": "string"}
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "required": ["prop1"]
+                }'
+            ),
         );
     }
 


### PR DESCRIPTION
The resolution of the definitions of the objects for the `oneOf` constraint with `$ref` referencing something works, but the actual validation of the objects then fails for the second added test case with ```prop2 – failed to match exactly one schema```.

See https://gist.github.com/graste/968573d9c29280b66a7c as well for a small usecase/example.

DON'T JUST MERGE this PR as it contains a failing test case deliberately.