### PR TITLE
bugfix: patternProperties raised errors when the pattern has slashes

### DIFF
--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -42,15 +42,23 @@ class ObjectConstraint extends Constraint
 
     public function validatePatternProperties($element, $path, $patternProperties)
     {
+        $try = array('/','#','+','~','%');
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {
+            // Choose delimiter. Necessary for patterns like ^/ , otherwise you get error
+            foreach ($try as $delimiter) {
+                if (strpos($pregex, $delimiter) === false) { // safe to use
+                    break;
+                }
+            }
+
             // Validate the pattern before using it to test for matches
-            if (@preg_match('/'. $pregex . '/', '') === false) {
+            if (@preg_match($delimiter. $pregex . $delimiter, '') === false) {
                 $this->addError($path, 'The pattern "' . $pregex . '" is invalid', 'pregex', array('pregex' => $pregex,));
                 continue;
             }
             foreach ($element as $i => $value) {
-                if (preg_match('/' . $pregex . '/', $i)) {
+                if (preg_match($delimiter . $pregex . $delimiter, $i)) {
                     $matches[] = $i;
                     $this->checkUndefined($value, $schema ? : new \stdClass(), $path, $i);
                 }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -45,6 +45,7 @@ class ObjectConstraint extends Constraint
         $try = array('/','#','+','~','%');
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {
+            $delimiter = '/';
             // Choose delimiter. Necessary for patterns like ^/ , otherwise you get error
             foreach ($try as $delimiter) {
                 if (strpos($pregex, $delimiter) === false) { // safe to use

--- a/tests/JsonSchema/Tests/Constraints/PatternPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/PatternPropertiesTest.php
@@ -82,10 +82,29 @@ class PatternPropertiesTest extends BaseTestCase
                     ),
                     'someotherobject' => array(
                         'foobar' => 1234,
+                    ),
+                    '/products' => array(
+                        'get' => array()
+                    ),
+                    '#products' => array(
+                        'get' => array()
+                    ),
+                    '+products' => array(
+                        'get' => array()
+                    ),
+                    '~products' => array(
+                        'get' => array()
+                    ),
+                    '*products' => array(
+                        'get' => array()
+                    ),
+                    '%products' => array(
+                        'get' => array()
                     )
                 )),
                 json_encode(array(
                     'type' => 'object',
+                    'additionalProperties' => false,
                     'patternProperties' => array(
                         '^someobject$' => array(
                             'type' => 'object',
@@ -100,6 +119,42 @@ class PatternPropertiesTest extends BaseTestCase
                                 'foobar' => array('type' => 'number'),
                             ),
                         ),
+                        '^/' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        ),
+                        '^#' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        ),
+                        '^\+' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        ),
+                        '^~' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        ),
+                        '^\*' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        ),
+                        '^%' => array(
+                            'type' => 'object',
+                            'properties' => array(
+                                'get' => array('type' => 'array')
+                            )
+                        )
                     )
                 ))
             ),


### PR DESCRIPTION
Now the delimiter to evaluate the regex is chosen dynamically.