### PR TITLE
Better enum constraint error message

### DIFF
--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -41,6 +41,31 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, "Does not have a value in the enumeration " . print_r($schema->enum, true), 'enum', array('enum' => $schema->enum,));
+        $this->addError($path, "value is not in enumeration: [" . $this->enumToString($schema->enum) . "]", 'enum', array('enum' => $schema->enum,));
+    }
+
+    /**
+     * @param array $enum
+     * @return string
+     */
+    private function enumToString(array $enum)
+    {
+        $enumString = '';
+
+        foreach ($enum as $value) {
+            if (is_array($value)) {
+                $enumString += '[' . $this->enumToString($value) . ']' . ', ';
+                continue;
+            }
+
+            if (is_object($value)) {
+                $enumString += print_r($value, true) . ', ';
+                continue;
+            }
+
+            $enumString += $value . ', ';
+        }
+
+        return rtrim($enumString, ', ');
     }
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -59,7 +59,7 @@ class EnumConstraint extends Constraint
             }
 
             if (is_object($value)) {
-                $enumString += print_r($value, true) . ', ';
+                $enumString += '[' . $this->enumToString((array) $value) . ']' . ', ';
                 continue;
             }
 


### PR DESCRIPTION
Currently `EnumConstraint` uses `print_r` which produces messages like:

```
Does not have a value in the enumeration Array\n(\n    [0] => GBP\n    [1] => USD\n)
```

Which is not the most friendly messaging in the world. I've changed this to handle more like this:

```
value is not in enumeration: [GBP, USD]
```

It makes it much easier to read for simple enums, for complex enums involving objects they are stilled handled with `print_r`.