### PR TITLE
Custom constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,32 @@ if ($validator->isValid()) {
 }
 ```
 
+## Custom Constraints
+Add custom constraints via `$validator->addConstraint($name, $constraint)`;
+
+The given `$constraint` is applied when `$name` is found within the current evaluated schema path.
+
+### Add a callable constraint
+
+	$validator->addConstraint('test', \Callable);
+
+ * Inherits _current_ ctr params (uriRetriever, factory)
+ * The callable is the `ConstraintInterface->check` signature `function check($value, $schema = null, $path = null, $i = null)`
+
+### Add by custom Constraint instance
+	
+	$validator->addConstraint('test', new MyCustomConstraint(...));
+
+ * Requires adding the correct ctr params (uriRetriever, factory et al)
+ * `MyCustomConstraint` must be of type `JsonSchema\Constraints\ConstraintInterface`
+
+### Add by custom Constraint class-name
+
+	$validator->addConstraint('test', 'FQCN');
+
+ * Inherits _current_ ctr params (uriRetriever, factory)
+ * `FQCN` must be of type `JsonSchema\Constraints\ConstraintInterface`
+
 ## Running the tests
 
     $ vendor/bin/phpunit

--- a/src/JsonSchema/Constraints/CallableConstraint.php
+++ b/src/JsonSchema/Constraints/CallableConstraint.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace JsonSchema\Constraints;
+
+use JsonSchema\Uri\UriRetriever;
+
+/**
+ * CallableConstraint
+ *
+ * Used internally to register a custom callable constraint via:
+ *    ($validator|$factory)->addConstraint('name', \Callable)
+ *
+ */
+class CallableConstraint extends Constraint
+{
+
+    /**
+     * @var \Callable
+     */
+    private $callable;
+
+    /**
+     * @param int $checkMode
+     * @param UriRetriever $uriRetriever
+     * @param Factory $factory
+     * @param Callable $callable
+     */
+    public function __construct(
+        $checkMode = self::CHECK_MODE_NORMAL,
+        UriRetriever $uriRetriever = null,
+        Factory $factory = null,
+        $callable
+    ) {
+        $this->callable = $callable;
+        parent::__construct($checkMode, $uriRetriever, $factory);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function check($element, $schema = null, $path = null, $i = null)
+    {
+        if ( ! is_callable($this->callable)) {
+            return;
+        }
+
+        $result = call_user_func($this->callable, $element, $schema, $path, $i);
+
+        if ($result) {
+            $this->addError($path, $result);
+        }
+    }
+}

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -275,6 +275,14 @@ abstract class Constraint implements ConstraintInterface
         $this->addErrors($validator->getErrors());
     }
 
+    protected function checkCustom($constraint, $value, $schema = null, $path = null, $i = null)
+    {
+        $validator = $this->getFactory()->createInstanceFor($constraint);
+        $validator->check($value, $schema, $path, $i);
+
+        $this->addErrors($validator->getErrors());
+    }
+
     /**
      * @param string $uri JSON Schema URI
      * @return string JSON Schema contents

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -65,6 +65,8 @@ class Factory
      * @param string $name
      * @param ConstraintInterface|string|\Callable $constraint
      *
+     * @todo possible own exception?
+     *
      * @throws InvalidArgumentException if the $constraint is either not a class or not a ConstraintInterface
      */
     public function addConstraint($name, $constraint)
@@ -79,10 +81,12 @@ class Factory
 
         if (is_string($constraint)) {
             if ( ! class_exists($constraint)) {
+                // @todo possible own exception?
                 throw new InvalidArgumentException('Constraint class "' . $constraint . '" is not a Class');
             }
             $constraint = new $constraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
             if ( ! $constraint instanceof ConstraintInterface) {
+                // @todo possible own exception?
                 throw new InvalidArgumentException('Constraint class "' . get_class($constraint) . '" is not an instance of ConstraintInterface');
             }
         }

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -51,13 +51,28 @@ class Factory
     /**
      * Add a custom constraint
      *
-     *    $factory->addConstraint('name', new MyCustomConstraint(...));
+     * By instance:
+     *    $factory->addConstraint('name', new \FQCN(...)); // need to provide own ctr params
+     *
+     * By class name:
+     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current instance
      *
      * @param string $name
-     * @param ConstraintInterface $constraint
+     * @param ConstraintInterface|string $constraint
+     *
+     * @throws InvalidArgumentException if the $constraint is either not a class or not a ConstraintInterface
      */
     public function addConstraint($name, $constraint)
     {
+        if (is_string($constraint)) {
+            if (!class_exists($constraint)) {
+                throw new InvalidArgumentException('Constraint class "' . $constraint . '" is not a Class');
+            }
+            $constraint = new $constraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
+            if (!$constraint instanceof ConstraintInterface) {
+                throw new InvalidArgumentException('Constraint class "' . get_class($constraint) . '" is not an instance of ConstraintInterface');
+            }
+        }
         $this->constraints[$name] = $constraint;
     }
 

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -55,24 +55,38 @@ class Factory
      *    $factory->addConstraint('name', new \FQCN(...)); // need to provide own ctr params
      *
      * By class name:
-     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current instance
+     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current
+     *
+     * As a \Callable (the Constraint::checks() method):
+     *    $factory->addConstraint('name', \Callable); // inherits ctr params from current
+     *
+     * NOTE: By class-name or as a Callable will inherit the current configuration (uriRetriever, factory)
      *
      * @param string $name
-     * @param ConstraintInterface|string $constraint
+     * @param ConstraintInterface|string|\Callable $constraint
      *
      * @throws InvalidArgumentException if the $constraint is either not a class or not a ConstraintInterface
      */
     public function addConstraint($name, $constraint)
     {
+
+        if (is_callable($constraint)) {
+            $this->constraints[$name] = new CallableConstraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever,
+                $this, $constraint);
+
+            return;
+        }
+
         if (is_string($constraint)) {
-            if (!class_exists($constraint)) {
+            if ( ! class_exists($constraint)) {
                 throw new InvalidArgumentException('Constraint class "' . $constraint . '" is not a Class');
             }
             $constraint = new $constraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
-            if (!$constraint instanceof ConstraintInterface) {
+            if ( ! $constraint instanceof ConstraintInterface) {
                 throw new InvalidArgumentException('Constraint class "' . get_class($constraint) . '" is not an instance of ConstraintInterface');
             }
         }
+
         $this->constraints[$name] = $constraint;
     }
 

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -26,7 +26,7 @@ class Factory
     /**
      * @var array
      */
-    private $constraints = [];
+    private $constraints = array();
 
     /**
      * @param UriRetriever $uriRetriever

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -85,10 +85,11 @@ class Factory
                 throw new InvalidArgumentException('Constraint class "' . $constraint . '" is not a Class');
             }
             $constraint = new $constraint(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
-            if ( ! $constraint instanceof ConstraintInterface) {
-                // @todo possible own exception?
-                throw new InvalidArgumentException('Constraint class "' . get_class($constraint) . '" is not an instance of ConstraintInterface');
-            }
+        }
+
+        if ( ! $constraint instanceof ConstraintInterface) {
+            // @todo possible own exception?
+            throw new InvalidArgumentException('Constraint class "' . get_class($constraint) . '" is not an instance of ConstraintInterface');
         }
 
         $this->constraints[$name] = $constraint;

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -24,11 +24,16 @@ class Factory
     protected $uriRetriever;
 
     /**
+     * @var array
+     */
+    private $constraints = [];
+
+    /**
      * @param UriRetriever $uriRetriever
      */
     public function __construct(UriRetriever $uriRetriever = null)
     {
-        if (!$uriRetriever) {
+        if ( ! $uriRetriever) {
             $uriRetriever = new UriRetriever();
         }
 
@@ -44,9 +49,34 @@ class Factory
     }
 
     /**
+     * Add a custom constraint
+     *
+     *    $factory->addConstraint('name', new MyCustomConstraint(...));
+     *
+     * @param string $name
+     * @param ConstraintInterface $constraint
+     */
+    public function addConstraint($name, $constraint)
+    {
+        $this->constraints[$name] = $constraint;
+    }
+
+    /**
+     * @param $constraintName
+     *
+     * @return bool
+     */
+    public function hasConstraint($constraintName)
+    {
+        return ! empty($this->constraints[$constraintName])
+               && $this->constraints[$constraintName] instanceof ConstraintInterface;
+    }
+
+    /**
      * Create a constraint instance for the given constraint name.
      *
      * @param string $constraintName
+     *
      * @return ConstraintInterface|ObjectConstraint
      * @throws InvalidArgumentException if is not possible create the constraint instance.
      */
@@ -76,6 +106,11 @@ class Factory
                 return new Validator(Constraint::CHECK_MODE_NORMAL, $this->uriRetriever, $this);
         }
 
+        if ($this->hasConstraint($constraintName)) {
+            return $this->constraints[$constraintName];
+        }
+
         throw new InvalidArgumentException('Unknown constraint ' . $constraintName);
     }
+
 }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -47,6 +47,24 @@ class UndefinedConstraint extends Constraint
 
         // check known types
         $this->validateTypes($value, $schema, $path, $i);
+
+        // check custom
+        $this->validateCustom($value, $schema, $path, $i);
+    }
+
+    /**
+     * @param $value
+     * @param null $schema
+     * @param null $path
+     * @param null $i
+     */
+    public function validateCustom($value, $schema = null, $path = null, $i = null)
+    {
+        foreach (array_keys((array)$schema) as $check) {
+            if ($this->getFactory()->hasConstraint($check)) {
+                $this->checkCustom($check, $value, $check, $path, $i);
+            }
+        }
     }
 
     /**

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -12,6 +12,7 @@ namespace JsonSchema;
 use JsonSchema\Constraints\ConstraintInterface;
 use JsonSchema\Constraints\SchemaConstraint;
 use JsonSchema\Constraints\Constraint;
+use JsonSchema\Exception\InvalidArgumentException;
 
 /**
  * A JsonSchema Constraint
@@ -42,11 +43,16 @@ class Validator extends Constraint
     /**
      * Add a custom constraint
      *
-     *    // extends Constraint or implements ConstraintInterface
-     *    $factory->addConstraint('name', new MyCustomConstraint(...));
+     * By instance:
+     *    $factory->addConstraint('name', new \FQCN(...)); // need to provide own ctr params
+     *
+     * By class name:
+     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current instance
      *
      * @param string $name
-     * @param ConstraintInterface $constraint
+     * @param ConstraintInterface|string $constraint
+     *
+     * @throws InvalidArgumentException if the $constraint is either not a class or not a ConstraintInterface
      */
     public function addConstraint($name, $constraint)
     {

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema;
 
+use JsonSchema\Constraints\ConstraintInterface;
 use JsonSchema\Constraints\SchemaConstraint;
 use JsonSchema\Constraints\Constraint;
 
@@ -36,5 +37,19 @@ class Validator extends Constraint
         $validator->check($value, $schema);
 
         $this->addErrors(array_unique($validator->getErrors(), SORT_REGULAR));
+    }
+
+    /**
+     * Add a custom constraint
+     *
+     *    // extends Constraint or implements ConstraintInterface
+     *    $factory->addConstraint('name', new MyCustomConstraint(...));
+     *
+     * @param string $name
+     * @param ConstraintInterface $constraint
+     */
+    public function addConstraint($name, $constraint)
+    {
+        $this->getFactory()->addConstraint($name, $constraint);
     }
 }

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -47,10 +47,15 @@ class Validator extends Constraint
      *    $factory->addConstraint('name', new \FQCN(...)); // need to provide own ctr params
      *
      * By class name:
-     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current instance
+     *    $factory->addConstraint('name', '\FQCN'); // inherits ctr params from current
+     *
+     * As a \Callable (the Constraint::checks() method):
+     *    $factory->addConstraint('name', \Callable); // inherits ctr params from current
+     *
+     * NOTE: By class-name or as a Callable will inherit the current configuration (uriRetriever, factory)
      *
      * @param string $name
-     * @param ConstraintInterface|string $constraint
+     * @param ConstraintInterface|string|\Callable $constraint
      *
      * @throws InvalidArgumentException if the $constraint is either not a class or not a ConstraintInterface
      */

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -10,7 +10,6 @@
 namespace JsonSchema;
 
 use JsonSchema\Constraints\ConstraintInterface;
-use JsonSchema\Constraints\SchemaConstraint;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\InvalidArgumentException;
 

--- a/tests/JsonSchema/Tests/Constraints/CustomConstraintTest.php
+++ b/tests/JsonSchema/Tests/Constraints/CustomConstraintTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+use PHPUnit_Framework_TestCase as TestCase;
+use JsonSchema\Constraints\Factory;
+use JsonSchema\Constraints\Constraint;
+
+class CustomConstraintTest extends TestCase
+{
+    /**
+     * @var Factory
+     */
+    protected $factory;
+
+    protected function setUp()
+    {
+        $this->factory = new Factory();
+    }
+
+    /**
+     * @dataProvider constraintNameProvider
+     *
+     * @param string $constraintName
+     * @param string $expectedClass
+     */
+    public function testConstraintInstanceWithoutCtrParams($constraintName, $expectedClass)
+    {
+        $this->factory->addConstraint($constraintName, new $expectedClass());
+        $constraint = $this->factory->createInstanceFor($constraintName);
+
+        $this->assertInstanceOf($expectedClass, $constraint);
+        $this->assertInstanceOf('JsonSchema\Constraints\ConstraintInterface', $constraint);
+        $this->assertNotSame($this->factory->getUriRetriever(), $constraint->getUriRetriever());
+    }
+
+    /**
+     * @dataProvider constraintNameProvider
+     *
+     * @param string $constraintName
+     * @param string $expectedClass
+     */
+    public function testConstraintInstanceWithCtrParams($constraintName, $expectedClass)
+    {
+        $this->factory->addConstraint($constraintName,
+            new $expectedClass(Constraint::CHECK_MODE_NORMAL, $this->factory->getUriRetriever(), $this->factory));
+        $constraint = $this->factory->createInstanceFor($constraintName);
+
+        $this->assertInstanceOf($expectedClass, $constraint);
+        $this->assertInstanceOf('JsonSchema\Constraints\ConstraintInterface', $constraint);
+        $this->assertSame($this->factory->getUriRetriever(), $constraint->getUriRetriever());
+        $this->assertSame($this->factory, $constraint->getFactory());
+    }
+
+    /**
+     * @return array
+     */
+    public function constraintNameProvider()
+    {
+        return array(
+            array('exists', 'JsonSchema\Constraints\StringConstraint'),
+            array('custom', 'JsonSchema\Tests\Constraints\Fixtures\CustomConstraint'),
+        );
+    }
+
+}

--- a/tests/JsonSchema/Tests/Constraints/CustomConstraintTest.php
+++ b/tests/JsonSchema/Tests/Constraints/CustomConstraintTest.php
@@ -111,4 +111,14 @@ class CustomConstraintTest extends TestCase
         $factory->createInstanceFor($name);
     }
 
+    /**
+     *
+     */
+    public function testConstraintCallable()
+    {
+        $factory = new Factory();
+        $factory->addConstraint('callable', function () {});
+        $this->assertInstanceOf('JsonSchema\Constraints\CallableConstraint', $factory->createInstanceFor('callable'));
+    }
+
 }

--- a/tests/JsonSchema/Tests/Constraints/Fixtures/CustomConstraint.php
+++ b/tests/JsonSchema/Tests/Constraints/Fixtures/CustomConstraint.php
@@ -1,0 +1,12 @@
+<?php
+namespace JsonSchema\Tests\Constraints\Fixtures;
+
+use \JsonSchema\Constraints\Constraint;
+
+class CustomConstraint extends Constraint
+{
+    public function check($value, $schema = null, $path = null, $i = null)
+    {
+    }
+
+}


### PR DESCRIPTION
Allows adding custom constraints via

    $validator->addConstraint('name', \Callable|className|instance)

**Background**
I ran in to the problem of custom constraints and via pr #143 by @Maks3w (the factory) the possiblity was available to easily accomplish adding custom constraints..  (this is moved from a @Maks3w fork)

**Implementation**
This allows applying custom constraints, by name, as either a callable/className/instance.
_I am not saying this is how it should be_ --- all input welcome.

i.e. schema

	{ 'myCustomCheck': value }

Can be constrained via `$validator->addConstraint('myCustomCheck', $constraint)`

#### Add a callable constraint

	$validator->addConstraint('test', \Callable);

 * Inherits _current/default_ ctr params (mode, uriRetriever, factory) - what the factory does internally
 * The callable is the `ConstraintInterface->check` signature `function ($value, $schema = null, $path = null, $i = null)`

#### Add by Constraint class-name

	$validator->addConstraint('test', 'FQCN');

 * Inherits _current/default_ ctr params (mode, uriRetriever, factory) - what the factory does internally
 * `FQCN` must be of type `JsonSchema\Constraints\ConstraintInterface`

#### Add by Constraint instance
	
	$validator->addConstraint('test', new MyCustomConstraint(...));

 * Possibly requires adding the correct ctr params (mode, uriRetriever, factory et al) - what the factory does internally; If not the mode will be the default and the uriRetriever/factory will be another instance (if this is a problem remains to be seen)
 * `MyCustomConstraint` must be of type `JsonSchema\Constraints\ConstraintInterface`

