### PR TITLE
Fix CollectionConstraint to allow uniqueItems to be false

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -33,7 +33,7 @@ class CollectionConstraint extends Constraint
         }
 
         // Verify uniqueItems
-        if (isset($schema->uniqueItems)) {
+        if (isset($schema->uniqueItems) && $schema->uniqueItems) {
             $unique = $value;
             if (is_array($value) && count($value)) {
                 $unique = array_map(function($e) { return var_export($e, true); }, $value);


### PR DESCRIPTION
According to the latest [json-schema-validation](http://json-schema.org/latest/json-schema-validation.html#anchor49).
uniqueItems should be either a boolean or if not present, set to false