### PR TITLE
Updated tests to reflect pull request #200

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/UniqueItemsTest.php
+++ b/tests/JsonSchema/Tests/Constraints/UniqueItemsTest.php
@@ -110,6 +110,49 @@ class UniqueItemsTest extends BaseTestCase
                     "type": "array",
                     "uniqueItems": true
                 }'
+            ),
+            // below equals the invalid tests, but with uniqueItems set to false
+            array(
+                '[1,2,2]',
+                '{
+                  "type":"array",
+                  "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{"a":"b"},{"a":"c"},{"a":"b"}]',
+                '{
+                  "type":"array",
+                  "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[1.0, 1.00, 1]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[["foo"], ["foo"]]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{}, [1], true, null, {}, 1]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
             )
         );
     }


### PR DESCRIPTION
Fix CollectionConstraint to allow uniqueItems to be false [(pull request #200)](https://github.com/justinrainbow/json-schema/pull/200)

According to the latest [json-schema-validation](http://json-schema.org/latest/json-schema-validation.html#anchor49).
uniqueItems should be either a boolean or if not present, set to false