### PR TITLE
Fix CollectionConstraint to allow uniqueItems to be false

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -33,7 +33,7 @@ class CollectionConstraint extends Constraint
         }
 
         // Verify uniqueItems
-        if (isset($schema->uniqueItems)) {
+        if (isset($schema->uniqueItems) && $schema->uniqueItems) {
             $unique = $value;
             if (is_array($value) && count($value)) {
                 $unique = array_map(function($e) { return var_export($e, true); }, $value);

--- a/tests/JsonSchema/Tests/Constraints/UniqueItemsTest.php
+++ b/tests/JsonSchema/Tests/Constraints/UniqueItemsTest.php
@@ -110,6 +110,49 @@ class UniqueItemsTest extends BaseTestCase
                     "type": "array",
                     "uniqueItems": true
                 }'
+            ),
+            // below equals the invalid tests, but with uniqueItems set to false
+            array(
+                '[1,2,2]',
+                '{
+                  "type":"array",
+                  "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{"a":"b"},{"a":"c"},{"a":"b"}]',
+                '{
+                  "type":"array",
+                  "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{"foo": {"bar" : {"baz" : true}}}, {"foo": {"bar" : {"baz" : true}}}]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[1.0, 1.00, 1]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[["foo"], ["foo"]]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
+            ),
+            array(
+                '[{}, [1], true, null, {}, 1]',
+                '{
+                    "type": "array",
+                    "uniqueItems": false
+                }'
             )
         );
     }


### PR DESCRIPTION
According to the latest [json-schema-validation](http://json-schema.org/latest/json-schema-validation.html#anchor49).
uniqueItems should be either a boolean or if not present, set to false