### PR TITLE
Fix path output for required properties

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -121,7 +121,7 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError($required, "The property " . $required . " is required", 'required');
+                        $this->addError((!$path) ? $required : "$path.$required", "The property " . $required . " is required", 'required');
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {

--- a/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
+++ b/tests/JsonSchema/Tests/Constraints/RequiredPropertyTest.php
@@ -38,6 +38,39 @@ class RequiredPropertyTest extends BaseTestCase
         $this->assertErrorHasExpectedPropertyValue($error, "foo");
     }
 
+    public function testPathErrorPropertyIsPopulatedForRequiredIfMissingInInput()
+    {
+        $validator = new UndefinedConstraint();
+        $document = json_decode(
+            '{
+                "foo": [{"baz": 1.5}]
+            }'
+        );
+        $schema = json_decode(
+            '{
+                "type": "object",
+                "properties": {
+                    "foo": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "bar": {"type": "number"},
+                                "baz": {"type": "number"}
+                            },
+                            "required": ["bar"]
+                        }
+                    }
+                },
+                "required": ["foo"]
+            }'
+        );
+
+        $validator->check($document, $schema);
+        $error = $validator->getErrors();
+        $this->assertErrorHasExpectedPropertyValue($error, "foo[0].bar");
+    }
+
     public function testErrorPropertyIsPopulatedForRequiredIfEmptyValueInInput()
     {
         $validator = new UndefinedConstraint();


### PR DESCRIPTION
Example:

Before:
```day: "The property day is required"```
After
```availability[0].hours[0].day: "The property day is required"```