### PR TITLE
An email is a string, not much else.

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -127,6 +127,10 @@ class TypeConstraint extends Constraint
         if ('string' === $type) {
             return is_string($value);
         }
+        
+        if ('email' === $type) {
+            return is_string($value);
+        }
 
         if ('null' === $type) {
             return is_null($value);


### PR DESCRIPTION
Fixes #205 Using email as type now works! 