### PR TITLE
feat(composer): require PHP 5.3.29 (PHP 5.3.x EOL version) minimum

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.3.3
     - php: 5.3
     - php: 5.4
     - php: 5.5

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         }
     }],
     "require": {
-        "php": ">=5.3.2"
+        "php": ">=5.3.29"
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.1.0",


### PR DESCRIPTION
With PHP 5.3.x EOL as of 8/14/2014 it is time to remove support for PHP 5.3.x versions prior to the last version.

https://secure.php.net/releases/5_3_29.php