### PR TITLE
Update StringConstraint.php

### DIFF
--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -37,10 +37,10 @@ class StringConstraint extends Constraint
         }
 
         // Verify a regex pattern
-        if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
-            $this->addError($path, "Does not match the regex pattern " . $schema->pattern, 'pattern', array(
+        if ( isset( $schema->pattern ) && !@preg_match( $schema->pattern, $element )) {
+            $this->addError( $path, "Does not match the regex pattern " . $schema->pattern, 'pattern', array(
                 'pattern' => $schema->pattern,
-            ));
+            ) );
         }
 
         $this->checkFormat($element, $schema, $path, $i);


### PR DESCRIPTION
- Regex limitations removed because of starting and ending #
- add-et @preg_match to avoid regex notices and warnings 

This will allow developers to create more complicated regex patterns for example #u as usage of Unicode ... only extra work in Schema is to supply pattern with starting and ending #