### PR TITLE
Fix: Attempt to cache dependencies installed with composer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: php
 
+env:
+  global:
+    - secure: "foo"
+
 matrix:
   fast_finish: true
   include:
@@ -19,6 +23,7 @@ cache:
 
 before_install:
   - composer selfupdate
+  - composer config github-oauth.github.com $GITHUB_TOKEN
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,15 @@ matrix:
   allow_failures:
     - php: 7
 
+cache:
+  directories:
+    - $HOME/.composer/cache
+
 before_install:
   - composer selfupdate
 
 install:
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - vendor/bin/phpunit --coverage-text


### PR DESCRIPTION
This PR

* [x] attempts to cache dependencies installed with composer between builds (faster builds)
* [ ] authenticates with the GitHub API (requires work by you, @bighappyface)

Follows https://github.com/justinrainbow/json-schema/pull/222#issuecomment-174639086.

:information_desk_person: This should cut down the build time significantly; after all, more than 95% of the build time are spent on cloning the dependencies.