### PR TITLE
Fix: Generate coverage on one PHP version only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,16 +8,18 @@ matrix:
     - php: 5.4
     - php: 5.5
     - php: 5.6
+      env: WITH_COVERAGE=true
     - php: 7
     - php: hhvm
   allow_failures:
     - php: 7
 
 before_install:
+  - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
   - composer selfupdate
 
 install:
   - travis_retry composer install --no-interaction --prefer-source
 
 script:
-  - vendor/bin/phpunit --coverage-text
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then vendor/bin/phpunit --coverage-text; else vendor/bin/phpunit; fi


### PR DESCRIPTION
This PR

* [x] generates coverage on PHP5.6 only and disables xdebug otherwise

Follows https://github.com/justinrainbow/json-schema/pull/222#issuecomment-174639086.

:person_with_pouting_face: This should further cut down build time. Of course, this only makes sense when there aren't different execution paths on different PHP versions.