### PR TITLE
Add a test to show a bug on the date-time format constraint checker

### DIFF
--- a/tests/JsonSchema/Tests/Constraints/FormatTest.php
+++ b/tests/JsonSchema/Tests/Constraints/FormatTest.php
@@ -81,6 +81,7 @@ class FormatTest extends BaseTestCase
             array('2000-05-01T12:12:12+01:00', 'date-time'),
             array('2000-05-01T12:12:12.123456Z', 'date-time'),
             array('2000-05-01T12:12:12.123Z', 'date-time'),
+            array('2000-05-01T12:12:12.000Z', 'date-time'),
 
             array('0', 'utc-millisec'),
 


### PR DESCRIPTION
it was supposed to be solved in #207 like that:

```php
// handles the case where a non-6 digit microsecond datetime is passed
// which will fail the above string comparison because the passed
// $datetime may be '2000-05-01T12:12:12.123Z' but format() will return
// '2000-05-01T12:12:12.123000Z'
if ((strpos('u', $format) !== -1) && (intval($dt->format('u')) > 0)) {
    return true;
}
```
(see https://github.com/justinrainbow/json-schema/pull/207/files#diff-94f691bae259df522f96670badc55b60R141)

but I'm not sure this is valid and I don't know how to solve it correctly easily. So for now this PR just shows the bug, I'll try to solve it later. if anyone have a suggestion, I'm all ears

maybe like mentioned on #145 ?