### PR TITLE
Fixup resolve URI from anchored sourceURI

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -88,8 +88,9 @@ class UriResolver
             return $uri;
         }
         $baseComponents = $this->parse($baseUri);
+        unset($baseComponents['fragment']);
         $basePath = $baseComponents['path'];
-        
+
         $baseComponents['path'] = self::combineRelativePathWithBasePath($path, $basePath);
         if (isset($components['fragment'])) {
             $baseComponents['fragment'] = $components['fragment'];

--- a/tests/JsonSchema/Tests/Uri/UriResolverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriResolverTest.php
@@ -93,7 +93,7 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException JsonSchema\Exception\UriResolverException
+     * @expectedException \JsonSchema\Exception\UriResolverException
      */
     public function testResolveRelativeUriNoBase()
     {
@@ -149,6 +149,18 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testResolveRelativeUriBaseFileAnchored()
+    {
+        $this->assertEquals(
+            'http://example.org/foo/baz.json',
+            $this->resolver->resolve(
+                'baz.json',
+                'http://example.org/foo/bar.json#baz'
+            )
+        );
+    }
+
     public function testResolveAnchorAnchor()
     {
         $this->assertEquals(


### PR DESCRIPTION
When using resolver with a base URI which has an anchored, the resolved URI keep the base URI anchor.

This patch ensures frament part of baseURI is removed before generating URI.

```php
use JsonSchema\Uri\UriResolver;

$resolver = new UriResolver();

echo $resolver->resolve('baz.json', 'http://example.org/foo/bar.json#baz');

// expected: http://example.org/foo/baz.json
// actual:   http://example.org/foo/baz.json#baz
```
