### PR TITLE
Aligning EnumConstraint error output to use json_encode()

### DIFF
--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -41,6 +41,6 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, "Does not have a value in the enumeration " . print_r($schema->enum, true), 'enum', array('enum' => $schema->enum,));
+        $this->addError($path, "Does not have a value in the enumeration " . json_encode($schema->enum), 'enum', array('enum' => $schema->enum,));
     }
 }


### PR DESCRIPTION
json_encode() is also used in FormatConstraint.

Example output
`
["message"]=>string(70) "Does not have a value in the enumeration ["Abacate","Manga","Pitanga"]"
`

