### PR TITLE
add rfc3339 helper class

### DIFF
--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -8,6 +8,7 @@
  */
 
 namespace JsonSchema\Constraints;
+use JsonSchema\Rfc3339;
 
 /**
  * Validates against the "format" property
@@ -40,11 +41,7 @@ class FormatConstraint extends Constraint
                 break;
 
             case 'date-time':
-                if (!$this->validateDateTime($element, 'Y-m-d\TH:i:s\Z') &&
-                    !$this->validateDateTime($element, 'Y-m-d\TH:i:s.u\Z') &&
-                    !$this->validateDateTime($element, 'Y-m-d\TH:i:sP') &&
-                    !$this->validateDateTime($element, 'Y-m-d\TH:i:sO')
-                ) {
+                if (null === Rfc3339::createFromString($element)) {
                     $this->addError($path, sprintf('Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm', json_encode($element)), 'format', array('format' => $schema->format,));
                 }
                 break;
@@ -130,19 +127,7 @@ class FormatConstraint extends Constraint
             return false;
         }
 
-        if ($datetime === $dt->format($format)) {
-            return true;
-        }
-
-        // handles the case where a non-6 digit microsecond datetime is passed
-        // which will fail the above string comparison because the passed
-        // $datetime may be '2000-05-01T12:12:12.123Z' but format() will return
-        // '2000-05-01T12:12:12.123000Z'
-        if ((strpos('u', $format) !== -1) && (intval($dt->format('u')) > 0)) {
-            return true;
-        }
-
-        return false;
+        return $datetime === $dt->format($format);
     }
 
     protected function validateRegex($regex)

--- a/src/JsonSchema/Rfc3339.php
+++ b/src/JsonSchema/Rfc3339.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace JsonSchema;
+
+class Rfc3339
+{
+    const REGEX = '/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))/';
+
+    /**
+     * Try creating a DateTime instance
+     *
+     * @param string $string
+     * @return \DateTime|null
+     */
+    public static function createFromString($string)
+    {
+        if (!preg_match(self::REGEX, strtoupper($string), $matches)) {
+            return null;
+        }
+
+        $dateAndTime = $matches[1];
+        $microseconds = $matches[2] ?: '.000000';
+        $timeZone = 'Z' !== $matches[3] ? $matches[4] . ':' . $matches[5] : '+00:00';
+
+        $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:s.uP', $dateAndTime . $microseconds . $timeZone, new \DateTimeZone('UTC'));
+
+        return $dateTime ?: null;
+    }
+}

--- a/tests/JsonSchema/Tests/Rfc3339Test.php
+++ b/tests/JsonSchema/Tests/Rfc3339Test.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace JsonSchema\Tests;
+
+use JsonSchema\Rfc3339;
+
+class Rfc3339Test extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $string
+     * @param \DateTime|null $expected
+     * @dataProvider provideValidFormats
+     */
+    public function testCreateFromValidString($string, \DateTime $expected)
+    {
+        $actual = Rfc3339::createFromString($string);
+
+        $this->assertInstanceOf('DateTime', $actual);
+        $this->assertEquals($expected->format('U.u'), $actual->format('U.u'));
+    }
+
+    /**
+     * @param string $string
+     * @dataProvider provideInvalidFormats
+     */
+    public function testCreateFromInvalidString($string)
+    {
+        $this->assertNull(Rfc3339::createFromString($string), sprintf('String "%s" should not be converted to DateTime', $string));
+    }
+
+    public function provideValidFormats()
+    {
+        return array(
+            array(
+                '2000-05-01T12:12:12Z',
+                \DateTime::createFromFormat('Y-m-d\TH:i:s', '2000-05-01T12:12:12', new \DateTimeZone('UTC'))
+            ),
+            array('2000-05-01T12:12:12+0100', \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')),
+            array('2000-05-01T12:12:12+01:00', \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')),
+            array(
+                '2000-05-01T12:12:12.123456Z',
+                \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
+            ),
+            array(
+                '2000-05-01T12:12:12.123Z',
+                \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
+            ),
+        );
+    }
+
+    public function provideInvalidFormats()
+    {
+        return array(
+            array('1999-1-11T00:00:00Z'),
+            array('1999-01-11T00:00:00+100'),
+            array('1999-01-11T00:00:00+1:00'),
+        );
+    }
+}


### PR DESCRIPTION
Using this helper class, it make it easy for clients of library to retrieve a proper instance of `DateTime` from their code.

```php
$element = '2016-03-03T13:40:42Z';

$constraint = new JsonSchema\Constraints\FormatConstraint();
$constraint->check($element, (object)array('format' => 'date-time'));

if (!$constraint->isValid()) {
  throw new RuntimeException('Error in element format');
}

$dateTime = JsonSchema\Rfc3339::createFromString($element);
```

If you do not want to fully check constraint, `JsonSchema\Rfc3339::createFromString()` will return `null` for invalid strings