### PR TITLE
Fix UriResolver::generate

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -58,10 +58,10 @@ class UriResolver
              . $components['authority']
              . $components['path'];
         
-        if (array_key_exists('query', $components)) {
-            $uri .= $components['query'];
+        if (!empty($components['query'])) {
+            $uri .= '?' . $components['query'];
         }
-        if (array_key_exists('fragment', $components)) {
+        if (!empty($components['fragment'])) {
             $uri .= '#' . $components['fragment'];
         }
         

--- a/tests/JsonSchema/Tests/Uri/UriResolverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriResolverTest.php
@@ -36,6 +36,33 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testGenerate()
+    {
+        $this->assertEquals(
+            'http://example.org/path/to/file.json?name=value#anchor',
+            $this->resolver->generate(array(
+                'scheme' => 'http',
+                'authority' => 'example.org',
+                'path' => '/path/to/file.json',
+                'query' => 'name=value',
+                'fragment' => 'anchor'
+            ))
+        );
+    }
+
+    public function testGenerateWithEmptyQueryAndWithoutFragment()
+    {
+        $this->assertEquals(
+            'http://example.org/path/to/file.json',
+            $this->resolver->generate(array(
+                'scheme' => 'http',
+                'authority' => 'example.org',
+                'path' => '/path/to/file.json',
+                'query' => '',
+            ))
+        );
+    }
+
     public function testCombineRelativePathWithBasePath()
     {
         $this->assertEquals(


### PR DESCRIPTION
Add '?' sign to query part.
Change array_key_exists to empty to avoid insertion '?' and '#' signs when corresponding parts are empty.