### PR TITLE
Fixing issue with non-object values

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -123,6 +123,11 @@ class UndefinedConstraint extends Constraint
                     $this->addError($path, "Is missing and it is required", 'required');
                 }
             }
+        } elseif (isset($schema->required) && is_array($schema->required)) {
+            // the value is not an object, but there are still required fields
+            foreach ($schema->required as $required) {
+                $this->addError((!$path) ? $required : "$path.$required", "The property " . $required . " is required", 'required');
+            }
         }
 
         // Verify type


### PR DESCRIPTION
If the value is not an object when checked by the UndefinedConstraint, it will
fail to check any required properties, making the value appear to be valid when
it isn't.

This fixes #254 

Signed-off-by: Nate Brunette <n@tebru.net>