### PR TITLE
feat(UriRetriever): application/json support

### DIFF
--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -51,7 +51,7 @@ class UriRetriever implements BaseUriRetrieverInterface
             return;
         }
 
-        if (Validator::SCHEMA_MEDIA_TYPE === $contentType) {
+        if (in_array($contentType, array(Validator::SCHEMA_MEDIA_TYPE, 'application/json'))) {
             return;
         }
 

--- a/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
+++ b/tests/JsonSchema/Tests/Uri/UriRetrieverTest.php
@@ -222,7 +222,7 @@ EOF;
             $schema, 'http://example.org/schema.json#/definitions/foo'
         );
     }
-    
+
     /**
      * @expectedException JsonSchema\Exception\UriResolverException
      */
@@ -232,5 +232,41 @@ EOF;
         $retriever->resolve(
             '../schema.json#', 'http://example.org/schema.json#'
         );
+    }
+
+    public function testConfirmMediaTypeAcceptsJsonSchemaType()
+    {
+      $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+
+      $retriever->expects($this->at(0))
+                ->method('getContentType')
+                ->will($this->returnValue('application/schema+json'));
+
+      $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+    }
+
+    public function testConfirmMediaTypeAcceptsJsonType()
+    {
+      $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+
+      $retriever->expects($this->at(0))
+                ->method('getContentType')
+                ->will($this->returnValue('application/json'));
+
+      $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
+    }
+
+    /**
+     * @expectedException \JsonSchema\Exception\InvalidSchemaMediaTypeException
+     */
+    public function testConfirmMediaTypeThrowsExceptionForUnsupportedTypes()
+    {
+      $retriever = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+
+      $retriever->expects($this->at(0))
+                ->method('getContentType')
+                ->will($this->returnValue('text/html'));
+
+      $this->assertEquals(null, $retriever->confirmMediaType($retriever, null));
     }
 }


### PR DESCRIPTION
This PR adds `application/json` as a supported media type in `JsonSchema/Uri/UriRetriever`.

See #257