### PR TITLE
Fixes min/max properties validation for non objects

### DIFF
--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -81,11 +81,7 @@ class ObjectConstraint extends Constraint
     {
         $this->validateMinMaxConstraint($element, $objectDefinition, $path);
         foreach ($element as $i => $value) {
-
-            $property = $this->getProperty($element, $i, new UndefinedConstraint());
             $definition = $this->getProperty($objectDefinition, $i);
-
-            $this->validateMinMaxConstraint(!($property instanceof UndefinedConstraint) ? $property : $element, $definition, $path);
 
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
@@ -110,6 +106,11 @@ class ObjectConstraint extends Constraint
             if (!$definition) {
                 // normal property verification
                 $this->checkUndefined($value, new \stdClass(), $path, $i);
+            }
+
+            $property = $this->getProperty($element, $i, new UndefinedConstraint());
+            if (is_object($property)) {
+                $this->validateMinMaxConstraint(!($property instanceof UndefinedConstraint) ? $property : $element, $definition, $path);
             }
         }
     }

--- a/tests/JsonSchema/Tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/JsonSchema/Tests/Constraints/MinMaxPropertiesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+class MinMaxPropertiesTest extends BaseTestCase
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getValidTests()
+    {
+        return array(
+            array(
+                '{
+                  "value": {}
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "minProperties": 0}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value": {}
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "maxProperties": 1}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value": {}
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "minProperties": 0,"maxProperties": 1}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value": {"foo": 1, "bar": 2}
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvalidTests()
+    {
+        return array(
+            array(
+                '{
+                  "value": 1
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "minProperties": 1}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value": 1
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "maxProperties": 1}
+                  }
+                }'
+            ),
+            array(
+                '{
+                  "value": {"foo": 1, "bar": 2, "baz": 3}
+                }',
+                '{
+                  "type": "object",
+                  "properties": {
+                    "value": {"type": "object", "minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
+        );
+    }
+}


### PR DESCRIPTION
I've added a few tests that covers the problem described in #260.

Also I went the way that previous implementation was done with single `if (is_object($property))`.
Please have a look at https://github.com/bighappyface/json-schema/blob/1.6.1/src/JsonSchema/Constraints/UndefinedConstraint.php#L169-L186 for reference.

Fixes #260

/cc @mirfilip @bighappyface