### PR TITLE
Do not override error handler

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -14,34 +14,29 @@ use JsonSchema\Validator;
 
 /**
  * Tries to retrieve JSON schemas from a URI using file_get_contents()
- * 
- * @author Sander Coolen <sander@jibber.nl> 
+ *
+ * @author Sander Coolen <sander@jibber.nl>
  */
 class FileGetContents extends AbstractRetriever
 {
     protected $messageBody;
-    
+
     /**
      * {@inheritDoc}
      * @see \JsonSchema\Uri\Retrievers\UriRetrieverInterface::retrieve()
      */
     public function retrieve($uri)
     {
-        $context = stream_context_create(array(
-            'http' => array(
-                'method' => 'GET',
-                'header' => "Accept: " . Validator::SCHEMA_MEDIA_TYPE
-            )));
-
-        set_error_handler(function() use ($uri) {
-            throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
-        });
-        $response = file_get_contents($uri);
-        restore_error_handler();
-
-        if (false === $response) {
+        if (!file_exists($uri)) {
             throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
         }
+
+        $response = file_get_contents($uri);
+
+        if (false === $response) {
+            throw new ResourceNotFoundException('JSON schema was not retrieved at ' . $uri);
+        }
+
         if ($response == ''
             && substr($uri, 0, 7) == 'file://' && substr($uri, -1) == '/'
         ) {
@@ -55,10 +50,10 @@ class FileGetContents extends AbstractRetriever
             // Could be a "file://" url or something else - fake up the response
             $this->contentType = null;
         }
-        
+
         return $this->messageBody;
     }
-    
+
     /**
      * @param array $headers HTTP Response Headers
      * @return boolean Whether the Content-Type header was found or not
@@ -70,10 +65,10 @@ class FileGetContents extends AbstractRetriever
                 return true;
             }
         }
-        
+
         return false;
     }
-    
+
     /**
      * @param string $header
      * @return string|null


### PR DESCRIPTION
### What does this PR Do?
Make use of [error control operator](http://php.net/manual/en/language.operators.errorcontrol.php) to suppress `E_WARNING` for `file_get_contents` if JSON schema not found. 

### Where should the reviewer start?
Check `JsonSchema\Uri\Retrievers\FileGetContents::retrieve` method and run unit test `vendor/bin/phpunit tests/JsonSchema/Tests/Uri/Retrievers/FileGetContentsTest.php`

### Any background context you want to provide?
It's a nice way to suppress php errors using `set_error_handler` function and make use of exceptions instead but it comes with one architectural flaw: exceptions thrown from overriden error handler bypass application stack trace. 
In my code I use a middleware which takes care of thrown exceptions on the top of my application stack and outputs nice response to a client. In case of overriding error handler (and even restoring it back right away) the error thrown from it bypasses my error handler thus resulting in `PHP Fatal error:  Uncaught exception 'JsonSchema\\Exception\\ResourceNotFoundException' with message 'JSON schema not found at file:...`
Use of error control operator allows to preserve functionality intact and gives a caller code ability to catch this exception within application stack. 

**UPD:** I know I can wrap a call to resolver in `try-catch` but I expect a more predictable behaviour. 
```
try {
    $schema = $refResolver->resolve('file://'.$events_create_schema);
} catch (ResourceNotFoundException $e) {
    // @TODO: take care of exception here
}
```