### PR TITLE
TypeConstraint checks if a value is really a numeric array or it's an object

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -144,9 +144,9 @@ class TypeConstraint extends Constraint
     }
 
     /**
-     * Check is the provided array is associative or not
+     * Check if the provided array is associative or not
      *
-     * @param $arr
+     * @param array $arr
      *
      * @return bool
      */

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -116,12 +116,12 @@ class TypeConstraint extends Constraint
         }
 
         if ('object' === $type) {
-            return is_object($value) || (is_array($value) && $this->isAssociativeArray($value));
+            return is_object($value) || (is_array($value) && (count($value) == 0 || $this->isAssociativeArray($value)));
             //return ($this::CHECK_MODE_TYPE_CAST == $this->checkMode) ? is_array($value) : is_object($value);
         }
 
         if ('array' === $type) {
-            return is_array($value) && !$this->isAssociativeArray($value);
+            return is_array($value) && (count($value) == 0 || !$this->isAssociativeArray($value));
         }
 
         if ('string' === $type) {

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -116,18 +116,18 @@ class TypeConstraint extends Constraint
         }
 
         if ('object' === $type) {
-            return is_object($value);
+            return is_object($value) || (is_array($value) && $this->isAssociativeArray($value));
             //return ($this::CHECK_MODE_TYPE_CAST == $this->checkMode) ? is_array($value) : is_object($value);
         }
 
         if ('array' === $type) {
-            return is_array($value);
+            return is_array($value) && !$this->isAssociativeArray($value);
         }
 
         if ('string' === $type) {
             return is_string($value);
         }
-        
+
         if ('email' === $type) {
             return is_string($value);
         }
@@ -141,5 +141,17 @@ class TypeConstraint extends Constraint
         }
 
         throw new InvalidArgumentException((is_object($value) ? 'object' : $value) . ' is an invalid type for ' . $type);
+    }
+
+    /**
+     * Check is the provided array is associative or not
+     *
+     * @param $arr
+     *
+     * @return bool
+     */
+    private function isAssociativeArray($arr)
+    {
+        return (array_keys($arr) !== range(0, count($arr) - 1));
     }
 }


### PR DESCRIPTION
As JSON objects are represented as PHP arrays once decoded, the type check didn't work when importing json or yaml files.
I improved the check for both arrays and objects.