### PR TITLE
Check headers for web-downloaded schemas instead of using file_exists

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -27,8 +27,15 @@ class FileGetContents extends AbstractRetriever
      */
     public function retrieve($uri)
     {
-        if (!file_exists($uri)) {
-            throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
+        if (preg_match('~https?://~i', $uri)) {
+            $headers = @get_headers($uri);
+            if (0 < mb_strpos($headers[0], ' 404 ')) {
+                throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
+            }
+        } else {
+            if (!file_exists($uri)) {
+                throw new ResourceNotFoundException('JSON schema not found at ' . $uri);
+            }
         }
 
         $response = file_get_contents($uri);


### PR DESCRIPTION
file_exists() doesn't work for URLs. This patch checks the headers for http(s) URIs and uses the old file_exists() for anything else.