### PR TITLE
use JsonPointer for path handling

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Entity\JsonPointer;
+
 /**
  * The CollectionConstraint Constraints, validates an array against a given schema
  *
@@ -20,7 +22,7 @@ class CollectionConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($value, $schema = null, $path = null, $i = null)
+    public function check($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
@@ -52,12 +54,12 @@ class CollectionConstraint extends Constraint
     /**
      * Validates the items
      *
-     * @param array     $value
-     * @param \stdClass $schema
-     * @param string    $path
-     * @param string    $i
+     * @param array            $value
+     * @param \stdClass        $schema
+     * @param JsonPointer|null $path
+     * @param string           $i
      */
-    protected function validateItems($value, $schema = null, $path = null, $i = null)
+    protected function validateItems($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         if (is_object($schema->items)) {
             // just one type definition for the whole array

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -265,7 +265,7 @@ abstract class Constraint implements ConstraintInterface
     }
 
     /**
-     * Checks format of a element
+     * Checks format of an element
      *
      * @param mixed            $value
      * @param mixed            $schema

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Constraints;
 
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
+use JsonSchema\Entity\JsonPointer;
 
 /**
  * The Base Constraints, all Validators should extend this class
@@ -80,10 +81,11 @@ abstract class Constraint implements ConstraintInterface
     /**
      * {@inheritDoc}
      */
-    public function addError($path, $message, $constraint='', array $more=null)
+    public function addError(JsonPointer $path = null, $message, $constraint='', array $more=null)
     {
         $error = array(
-            'property' => $path,
+            'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
+            'pointer' => ltrim(strval($path ?: new JsonPointer('')), '#'),
             'message' => $message,
             'constraint' => $constraint,
         );
@@ -132,37 +134,32 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Bubble down the path
      *
-     * @param string $path Current path
-     * @param mixed  $i    What to append to the path
+     * @param JsonPointer|null $path Current path
+     * @param mixed            $i    What to append to the path
      *
-     * @return string
+     * @return JsonPointer;
      */
-    protected function incrementPath($path, $i)
+    protected function incrementPath(JsonPointer $path = null, $i)
     {
-        if ($path !== '') {
-            if (is_int($i)) {
-                $path .= '[' . $i . ']';
-            } elseif ($i == '') {
-                $path .= '';
-            } else {
-                $path .= '.' . $i;
-            }
-        } else {
-            $path = $i;
-        }
-
+        $path = $path ?: new JsonPointer('');
+        $path = $path->withPropertyPaths(
+            array_merge(
+                $path->getPropertyPaths(),
+                array_filter(array($i), 'strlen')
+            )
+        );
         return $path;
     }
 
     /**
      * Validates an array
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      */
-    protected function checkArray($value, $schema = null, $path = null, $i = null)
+    protected function checkArray($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('collection');
         $validator->check($value, $schema, $path, $i);
@@ -173,13 +170,13 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Validates an object
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
-     * @param mixed $patternProperties
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
+     * @param mixed            $patternProperties
      */
-    protected function checkObject($value, $schema = null, $path = null, $i = null, $patternProperties = null)
+    protected function checkObject($value, $schema = null, JsonPointer $path = null, $i = null, $patternProperties = null)
     {
         $validator = $this->getFactory()->createInstanceFor('object');
         $validator->check($value, $schema, $path, $i, $patternProperties);
@@ -190,12 +187,12 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Validates the type of a property
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      */
-    protected function checkType($value, $schema = null, $path = null, $i = null)
+    protected function checkType($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('type');
         $validator->check($value, $schema, $path, $i);
@@ -206,12 +203,12 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Checks a undefined element
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      */
-    protected function checkUndefined($value, $schema = null, $path = null, $i = null)
+    protected function checkUndefined($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('undefined');
         $validator->check($value, $schema, $path, $i);
@@ -222,12 +219,12 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Checks a string element
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      */
-    protected function checkString($value, $schema = null, $path = null, $i = null)
+    protected function checkString($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('string');
         $validator->check($value, $schema, $path, $i);
@@ -238,12 +235,12 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Checks a number element
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed       $value
+     * @param mixed       $schema
+     * @param JsonPointer $path
+     * @param mixed       $i
      */
-    protected function checkNumber($value, $schema = null, $path = null, $i = null)
+    protected function checkNumber($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('number');
         $validator->check($value, $schema, $path, $i);
@@ -254,12 +251,12 @@ abstract class Constraint implements ConstraintInterface
     /**
      * Checks a enum element
      *
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      */
-    protected function checkEnum($value, $schema = null, $path = null, $i = null)
+    protected function checkEnum($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('enum');
         $validator->check($value, $schema, $path, $i);
@@ -267,7 +264,15 @@ abstract class Constraint implements ConstraintInterface
         $this->addErrors($validator->getErrors());
     }
 
-    protected function checkFormat($value, $schema = null, $path = null, $i = null)
+    /**
+     * Checks format of a element
+     *
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
+     */
+    protected function checkFormat($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('format');
         $validator->check($value, $schema, $path, $i);
@@ -297,5 +302,20 @@ abstract class Constraint implements ConstraintInterface
     protected function getTypeCheck()
     {
         return $this->getFactory()->getTypeCheck();
+    }
+
+    /**
+     * @param JsonPointer $pointer
+     * @return string property path
+     */
+    protected function convertJsonPointerIntoPropertyPath(JsonPointer $pointer)
+    {
+        $result = array_map(
+            function($path) {
+                return sprintf(is_numeric($path) ? '[%d]' : '.%s', $path);
+            },
+            $pointer->getPropertyPaths()
+        );
+        return trim(implode('', $result), '.');
     }
 }

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Entity\JsonPointer;
+
 /**
  * The Constraints Interface
  *
@@ -33,12 +35,12 @@ interface ConstraintInterface
     /**
      * adds an error
      *
-     * @param string $path
-     * @param string $message
-     * @param string $constraint the constraint/rule that is broken, e.g.: 'minLength'
-     * @param array $more more array elements to add to the error
+     * @param JsonPointer|null $path
+     * @param string           $message
+     * @param string           $constraint the constraint/rule that is broken, e.g.: 'minLength'
+     * @param array            $more more array elements to add to the error
      */
-    public function addError($path, $message, $constraint='', array $more=null);
+    public function addError(JsonPointer $path = null, $message, $constraint='', array $more=null);
 
     /**
      * checks if the validator has not raised errors
@@ -51,11 +53,11 @@ interface ConstraintInterface
      * invokes the validation of an element
      *
      * @abstract
-     * @param mixed $value
-     * @param mixed $schema
-     * @param mixed $path
-     * @param mixed $i
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
      * @throws \JsonSchema\Exception\ExceptionInterface
      */
-    public function check($value, $schema = null, $path = null, $i = null);
+    public function check($value, $schema = null, JsonPointer $path = null, $i = null);
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 use JsonSchema\Validator;
+use JsonSchema\Entity\JsonPointer;
 
 /**
  * The EnumConstraint Constraints, validates an element against a given set of possibilities
@@ -21,7 +22,7 @@ class EnumConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, $path = null, $i = null)
+    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -8,7 +8,9 @@
  */
 
 namespace JsonSchema\Constraints;
+
 use JsonSchema\Rfc3339;
+use JsonSchema\Entity\JsonPointer;
 
 /**
  * Validates against the "format" property
@@ -21,7 +23,7 @@ class FormatConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, $path = null, $i = null)
+    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
     {
         if (!isset($schema->format)) {
             return;

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Entity\JsonPointer;
+
 /**
  * The NumberConstraint Constraints, validates an number against a given schema
  *
@@ -20,7 +22,7 @@ class NumberConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, $path = null, $i = null)
+    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify minimum
         if (isset($schema->exclusiveMinimum)) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Entity\JsonPointer;
+
 /**
  * The ObjectConstraint Constraints, validates an object against a given schema
  *
@@ -20,7 +22,7 @@ class ObjectConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $definition = null, $path = null, $additionalProp = null, $patternProperties = null)
+    public function check($element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null)
     {
         if ($element instanceof UndefinedConstraint) {
             return;
@@ -40,7 +42,7 @@ class ObjectConstraint extends Constraint
         $this->validateElement($element, $matches, $definition, $path, $additionalProp);
     }
 
-    public function validatePatternProperties($element, $path, $patternProperties)
+    public function validatePatternProperties($element, JsonPointer $path = null, $patternProperties)
     {
         $try = array('/','#','+','~','%');
         $matches = array();
@@ -71,13 +73,13 @@ class ObjectConstraint extends Constraint
     /**
      * Validates the element properties
      *
-     * @param \stdClass $element          Element to validate
-     * @param array     $matches          Matches from patternProperties (if any)
-     * @param \stdClass $objectDefinition ObjectConstraint definition
-     * @param string    $path             Path to test?
-     * @param mixed     $additionalProp   Additional properties
+     * @param \stdClass        $element          Element to validate
+     * @param array            $matches          Matches from patternProperties (if any)
+     * @param \stdClass        $objectDefinition ObjectConstraint definition
+     * @param JsonPointer|null $path             Path to test?
+     * @param mixed            $additionalProp   Additional properties
      */
-    public function validateElement($element, $matches, $objectDefinition = null, $path = null, $additionalProp = null)
+    public function validateElement($element, $matches, $objectDefinition = null, JsonPointer $path = null, $additionalProp = null)
     {
         $this->validateMinMaxConstraint($element, $objectDefinition, $path);
         foreach ($element as $i => $value) {
@@ -118,11 +120,11 @@ class ObjectConstraint extends Constraint
     /**
      * Validates the definition properties
      *
-     * @param \stdClass $element          Element to validate
-     * @param \stdClass $objectDefinition ObjectConstraint definition
-     * @param string    $path             Path?
+     * @param \stdClass         $element          Element to validate
+     * @param \stdClass         $objectDefinition ObjectConstraint definition
+     * @param JsoinPointer|null $path             Path?
      */
-    public function validateDefinition($element, $objectDefinition = null, $path = null)
+    public function validateDefinition($element, $objectDefinition = null, JsonPointer $path = null)
     {
         foreach ($objectDefinition as $i => $value) {
             $property = $this->getProperty($element, $i, new UndefinedConstraint());
@@ -154,11 +156,11 @@ class ObjectConstraint extends Constraint
     /**
      * validating minimum and maximum property constraints (if present) against an element
      *
-     * @param \stdClass $element          Element to validate
-     * @param \stdClass $objectDefinition ObjectConstraint definition
-     * @param string    $path             Path to test?
+     * @param \stdClass        $element          Element to validate
+     * @param \stdClass        $objectDefinition ObjectConstraint definition
+     * @param JsonPointer|null $path             Path to test?
      */
-    protected function validateMinMaxConstraint($element, $objectDefinition, $path) {
+    protected function validateMinMaxConstraint($element, $objectDefinition, JsonPointer $path = null) {
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) < $objectDefinition->minProperties) {

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;
+use JsonSchema\Entity\JsonPointer;
 
 /**
  * The SchemaConstraint Constraints, validates an element against a given schema
@@ -22,19 +23,18 @@ class SchemaConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, $path = null, $i = null)
+    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
     {
         if ($schema !== null) {
             // passed schema
-            $this->checkUndefined($element, $schema, '', '');
+            $this->checkUndefined($element, $schema, $path, $i);
         } elseif ($this->getTypeCheck()->propertyExists($element, $this->inlineSchemaProperty)) {
             $inlineSchema = $this->getTypeCheck()->propertyGet($element, $this->inlineSchemaProperty);
             if (is_array($inlineSchema)) {
                 $inlineSchema = json_decode(json_encode($inlineSchema));
             }
-
             // inline schema
-            $this->checkUndefined($element, $inlineSchema, '', '');
+            $this->checkUndefined($element, $inlineSchema, $path, $i);
         } else {
             throw new InvalidArgumentException('no schema found to verify against');
         }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Entity\JsonPointer;
+
 /**
  * The StringConstraint Constraints, validates an string against a given schema
  *
@@ -20,7 +22,7 @@ class StringConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, $path = null, $i = null)
+    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;
+use JsonSchema\Entity\JsonPointer;
 use UnexpectedValueException as StandardUnexpectedValueException;
 
 /**
@@ -38,7 +39,7 @@ class TypeConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($value = null, $schema = null, $path = null, $i = null)
+    public function check($value = null, $schema = null, JsonPointer $path = null, $i = null)
     {
         $type = isset($schema->type) ? $schema->type : null;
         $isValid = true;

--- a/src/JsonSchema/Entity/JsonPointer.php
+++ b/src/JsonSchema/Entity/JsonPointer.php
@@ -101,6 +101,17 @@ class JsonPointer
     }
 
     /**
+     * @param array $propertyPaths
+     * @return JsonPointer
+     */
+    public function withPropertyPaths(array $propertyPaths)
+    {
+        $new = clone $this;
+        $new->propertyPaths = $propertyPaths;
+        return $new;
+    }
+
+    /**
      * @return string
      */
     public function getPropertyPathAsString()

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -11,6 +11,7 @@ namespace JsonSchema;
 
 use JsonSchema\Constraints\SchemaConstraint;
 use JsonSchema\Constraints\Constraint;
+use JsonSchema\Entity\JsonPointer;
 
 /**
  * A JsonSchema Constraint
@@ -30,7 +31,7 @@ class Validator extends Constraint
      *
      * {@inheritDoc}
      */
-    public function check($value, $schema = null, $path = null, $i = null)
+    public function check($value, $schema = null, JsonPointer $path = null, $i = null)
     {
         $validator = $this->getFactory()->createInstanceFor('schema');
         $validator->check($value, $schema);

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -34,6 +34,7 @@ class AdditionalPropertiesTest extends BaseTestCase
                 array(
                     array(
                         'property'   => '',
+                        'pointer'    => '',
                         'message'    => 'The property additionalProp is not defined and the definition does not allow additional properties',
                         'constraint' => 'additionalProp',
                     )

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
+use JsonSchema\Entity\JsonPointer;
 use PHPUnit_Framework_TestCase as TestCase;
 
 
@@ -25,7 +26,7 @@ class MyBadConstraint {}
  * @package JsonSchema\Tests\Constraints
  */
 class MyStringConstraint extends Constraint {
-  public function check($value, $schema = null, $path = null, $i = null){}
+  public function check($value, $schema = null, JsonPointer $path = null, $i = null){}
 }
 
 class FactoryTest extends TestCase

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -73,16 +73,19 @@ class OfPropertiesTest extends BaseTestCase
                 array(
                     array(
                         "property"   => "prop2",
+                        "pointer"    => "/prop2",
                         "message"    => "Array value found, but a string is required",
                         "constraint" => "type",
                     ),
                     array(
                         "property"   => "prop2",
+                        "pointer"    => "/prop2",
                         "message"    => "Array value found, but a number is required",
                         "constraint" => "type",
                     ),
                     array(
                         "property"   => "prop2",
+                        "pointer"    => "/prop2",
                         "message"    => "Failed to match exactly one schema",
                         "constraint" => "oneOf",
                     ),

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+use JsonSchema\Validator;
+
+class PointerTest extends \PHPUnit_Framework_TestCase
+{
+    public function testVariousPointers()
+    {
+        $schema = array(
+            'type' => 'object',
+            'required' => array('prop1', 'prop2', 'prop3', 'prop4'),
+            'properties' => array(
+                'prop1' => array(
+                    'type' => 'string'
+                ),
+                'prop2' => array(
+                    'type' => 'object',
+                    'required' => array('prop2.1'),
+                    'properties' => array(
+                        'prop2.1' => array(
+                            'type' => 'string'
+                        )
+                    )
+                ),
+                'prop3' => array(
+                    'type' => 'object',
+                    'required' => array('prop3/1'),
+                    'properties' => array(
+                        'prop3/1' => array(
+                            'type' => 'object',
+                            'required' => array('prop3/1.1'),
+                            'properties' => array(
+                                'prop3/1.1' => array(
+                                    'type' => 'string'
+                                )
+                            )
+                        )
+                    )
+                ),
+                'prop4' => array(
+                    'type' => 'array',
+                    'minItems' => 1,
+                    'items' => array(
+                        'type' => 'object',
+                        'required' => array('prop4-child'),
+                        'properties' => array(
+                            'prop4-child' => array(
+                                'type' => 'string'
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        $value = array(
+            'prop2' => array(
+                'foo' => 'bar'
+            ),
+            'prop3' => array(
+                'prop3/1' => array(
+                    'foo' => 'bar'
+                )
+            ),
+            'prop4' => array(
+                array(
+                    'foo' => 'bar'
+                )
+            )
+        );
+
+        $validator = new Validator();
+        $validator->check(json_decode(json_encode($value)), json_decode(json_encode($schema)));
+
+        $this->assertEquals(
+            array(
+                array(
+                    'property' => 'prop1',
+                    'pointer' => '/prop1',
+                    'message' => 'The property prop1 is required',
+                    'constraint' => 'required'
+                ),
+                array(
+                    'property' => 'prop2.prop2.1',
+                    'pointer' => '/prop2/prop2.1',
+                    'message' => 'The property prop2.1 is required',
+                    'constraint' => 'required'
+                ),
+                array(
+                    'property' => 'prop3.prop3/1.prop3/1.1',
+                    'pointer' => '/prop3/prop3~11/prop3~11.1',
+                    'message' => 'The property prop3/1.1 is required',
+                    'constraint' => 'required'
+                ),
+                array(
+                    'property' => 'prop4[0].prop4-child',
+                    'pointer' => '/prop4/0/prop4-child',
+                    'message' => 'The property prop4-child is required',
+                    'constraint' => 'required'
+                )
+            ),
+            $validator->getErrors()
+        );
+    }
+}

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -92,4 +92,22 @@ class JsonPointerTest extends \PHPUnit_Framework_TestCase
 
         );
     }
+
+    public function testJsonPointerWithPropertyPaths()
+    {
+        $initial = new JsonPointer('#/definitions/date');
+
+        $this->assertEquals(array('definitions', 'date'), $initial->getPropertyPaths());
+        $this->assertEquals('#/definitions/date', $initial->getPropertyPathAsString());
+
+        $modified = $initial->withPropertyPaths(array('~definitions/general', '%custom%'));
+
+        $this->assertNotSame($initial, $modified);
+
+        $this->assertEquals(array('definitions', 'date'), $initial->getPropertyPaths());
+        $this->assertEquals('#/definitions/date', $initial->getPropertyPathAsString());
+
+        $this->assertEquals(array('~definitions/general', '%custom%'), $modified->getPropertyPaths());
+        $this->assertEquals('#/~0definitions~1general/%25custom%25', $modified->getPropertyPathAsString());
+    }
 }


### PR DESCRIPTION
crafting a new API, trying to follow the jsonapi-specs, i've realized that  [error-objects](http://jsonapi.org/format/upcoming/#error-objects) require a json pointer:

> * `source`: an object containing references to the source of the error, optionally including any of the following members:
>   * `pointer`: a JSON Pointer [RFC6901] to the associated entity in the request document [e.g. `/data` for a primary data object, or `/data/attributes/title` for a specific attribute].

before making more changes, first thing to do was to get all tests working again, especially bringing back all the existing property paths since i don't intend to introduce a large BC which i probably still do? :/

having had a look at RFC6901 again, i'm curious why `JsonPointer#getPropertyPathAsString` does include a leading hashmark @jojo1981 - isn't that actually related to the filename rather than the path? checking other existing JsonPointer implementations in PHP, all use path expressions starting with a slash instead.

as a nice side-effect, using dots in keys wouldn't result in path that is rather hard to understand like `tld.company.project[0].content` (instead of `/tld.company.project/0/content`)

@mirfilip @bighappyface WDYT?