### PR TITLE
Exception interface

### DIFF
--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -55,6 +55,7 @@ interface ConstraintInterface
      * @param mixed $schema
      * @param mixed $path
      * @param mixed $i
+     * @throws \JsonSchema\Exception\ExceptionInterface
      */
     public function check($value, $schema = null, $path = null, $i = null);
 }

--- a/src/JsonSchema/Exception/ExceptionInterface.php
+++ b/src/JsonSchema/Exception/ExceptionInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace JsonSchema\Exception;
+
+interface ExceptionInterface
+{
+
+}

--- a/src/JsonSchema/Exception/InvalidArgumentException.php
+++ b/src/JsonSchema/Exception/InvalidArgumentException.php
@@ -12,6 +12,6 @@ namespace JsonSchema\Exception;
 /**
  * Wrapper for the InvalidArgumentException
  */
-class InvalidArgumentException extends \InvalidArgumentException
+class InvalidArgumentException extends \InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/JsonSchema/Exception/InvalidSchemaMediaTypeException.php
+++ b/src/JsonSchema/Exception/InvalidSchemaMediaTypeException.php
@@ -12,6 +12,6 @@ namespace JsonSchema\Exception;
 /**
  * Wrapper for the InvalidSchemaMediaType
  */
-class InvalidSchemaMediaTypeException extends \RuntimeException
+class InvalidSchemaMediaTypeException extends RuntimeException
 {    
 }

--- a/src/JsonSchema/Exception/JsonDecodingException.php
+++ b/src/JsonSchema/Exception/JsonDecodingException.php
@@ -12,7 +12,7 @@ namespace JsonSchema\Exception;
 /**
  * Wrapper for the JsonDecodingException
  */
-class JsonDecodingException extends \RuntimeException
+class JsonDecodingException extends RuntimeException
 {
     public function __construct($code = JSON_ERROR_NONE, \Exception $previous = null)
     {

--- a/src/JsonSchema/Exception/RuntimeException.php
+++ b/src/JsonSchema/Exception/RuntimeException.php
@@ -10,8 +10,8 @@
 namespace JsonSchema\Exception;
 
 /**
- * Wrapper for the ResourceNotFoundException
+ * Wrapper for the RuntimeException
  */
-class ResourceNotFoundException extends RuntimeException
+class RuntimeException extends \RuntimeException implements ExceptionInterface
 {
 }

--- a/src/JsonSchema/Exception/UnresolvableJsonPointerException.php
+++ b/src/JsonSchema/Exception/UnresolvableJsonPointerException.php
@@ -13,6 +13,6 @@ namespace JsonSchema\Exception;
  * @package JsonSchema\Exception
  * @author Joost Nijhuis <jnijhuis81@gmail.com>
  */
-class UnresolvableJsonPointerException extends \InvalidArgumentException
+class UnresolvableJsonPointerException extends InvalidArgumentException
 {
 }

--- a/src/JsonSchema/Exception/UriResolverException.php
+++ b/src/JsonSchema/Exception/UriResolverException.php
@@ -12,6 +12,6 @@ namespace JsonSchema\Exception;
 /**
  * Wrapper for the UriResolverException
  */
-class UriResolverException extends \RuntimeException
+class UriResolverException extends RuntimeException
 {
 }

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\InvalidArgumentException;
+
+class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new InvalidArgumentException();
+        self::assertInstanceOf('\InvalidArgumentException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
+++ b/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\InvalidSchemaMediaTypeException;
+
+class InvalidSchemaMediaTypeExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new InvalidSchemaMediaTypeException();
+        self::assertInstanceOf('\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/InvalidSourceUriExceptionTest.php
+++ b/tests/Exception/InvalidSourceUriExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\InvalidSourceUriException;
+
+class InvalidSourceUriExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new InvalidSourceUriException();
+        self::assertInstanceOf('\InvalidArgumentException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\InvalidArgumentException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/JsonDecodingExceptionTest.php
+++ b/tests/Exception/JsonDecodingExceptionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\JsonDecodingException;
+
+class JsonDecodingExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new JsonDecodingException();
+        self::assertInstanceOf('\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+    
+    public function testDefaultMessage()
+    {
+        $exception = new JsonDecodingException();
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorNoneMessage()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_NONE);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorDepthMessage()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_DEPTH);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorStateMismatchMessage()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_STATE_MISMATCH);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorControlCharacterMessage()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_CTRL_CHAR);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorUtf8Message()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_UTF8);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorSyntaxMessage()
+    {
+        $exception = new JsonDecodingException(JSON_ERROR_SYNTAX);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorInfiniteOrNotANumberMessage()
+    {
+        if (!defined('JSON_ERROR_INF_OR_NAN')) {
+            self::markTestSkipped('JSON_ERROR_INF_OR_NAN is not defined until php55.');
+        }
+        
+        $exception = new JsonDecodingException(JSON_ERROR_INF_OR_NAN);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorRecursionMessage()
+    {
+        if (!defined('JSON_ERROR_RECURSION')) {
+            self::markTestSkipped('JSON_ERROR_RECURSION is not defined until php55.');
+        }
+
+        $exception = new JsonDecodingException(JSON_ERROR_RECURSION);
+        self::assertNotEmpty($exception->getMessage());
+    }
+    
+    public function testErrorUnsupportedTypeMessage()
+    {
+        if (!defined('JSON_ERROR_UNSUPPORTED_TYPE')) {
+            self::markTestSkipped('JSON_ERROR_UNSUPPORTED_TYPE is not defined until php55.');
+        }
+
+        $exception = new JsonDecodingException(JSON_ERROR_UNSUPPORTED_TYPE);
+        self::assertNotEmpty($exception->getMessage());
+    }
+}

--- a/tests/Exception/ResourceNotFoundExceptionTest.php
+++ b/tests/Exception/ResourceNotFoundExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\ResourceNotFoundException;
+
+class ResourceNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new ResourceNotFoundException();
+        self::assertInstanceOf('\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\RuntimeException;
+
+class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new RuntimeException();
+        self::assertInstanceOf('\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/UnresolvableJsonPointerExceptionTest.php
+++ b/tests/Exception/UnresolvableJsonPointerExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\UnresolvableJsonPointerException;
+
+class UnresolvableJsonPointerExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new UnresolvableJsonPointerException();
+        self::assertInstanceOf('\InvalidArgumentException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\InvalidArgumentException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}

--- a/tests/Exception/UriResolverExceptionTest.php
+++ b/tests/Exception/UriResolverExceptionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Tests\Exception;
+
+use JsonSchema\Exception\UriResolverException;
+
+class UriResolverExceptionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHierarchy()
+    {
+        $exception = new UriResolverException();
+        self::assertInstanceOf('\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\RuntimeException', $exception);
+        self::assertInstanceOf('\JsonSchema\Exception\ExceptionInterface', $exception);
+    }
+}


### PR DESCRIPTION
* add `\RuntimeException` wrapper.
* update all extensions of `\RuntimeException` to extend the wrapper.
* SPL-exception wrappers now implement a common exception interface for this package. this allows consumers to handle all custom exception types thrown by catching the common interface rather than by catching each specific extension or their SPL parents.
* add tests to validate existing exception hierarchy, in preparation for adjustment.
* add tests for changes to exception hierarchy.
* document exception interface in `\JsonSchema\Constraints\ConstraintInterface`.

as a consumer, this change will allow me to handle exceptions from this package like this:
```
try {
  $validator->check($value, $schema);
} catch (\JsonSchema\Exception\ExceptionInterface $exception) {
  // Handle all JsonSchema exceptions.
}
```

instead of this:
```
try {
  $validator->check($value, $schema);
} catch (\JsonSchema\Exception\InvalidArgumentException $exception) {
  // Handle all JsonSchema invalid-argument exceptions.
} catch (\JsonSchema\Exception\JsonDecodingException $exception) {
  // Handle JsonSchema decoding exception.
}
// Additional catch-blocks for all \RuntimeException children.
```

or worse:
```
try {
  $validator->check($value, $schema);
} catch (\InvalidArgumentException $exception) {
  // Handle all invalid-argument exceptions, not just JsonSchema exceptions.
} catch (\RuntimeException $exception) {
    // Handle all runtime-argument exceptions, not just JsonSchema exceptions.
} catch (\Exception $exception) {
    // Handle all exceptions, not just JsonSchema exceptions.
}
```