### PR TITLE
fix instancing wrong type, breaks inheritance

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -48,7 +48,7 @@ class TypeConstraint extends Constraint
             $validatedOneType = false;
             $errors = array();
             foreach ($type as $tp) {
-                $validator = new TypeConstraint($this->checkMode);
+                $validator = new static($this->checkMode);
                 $subSchema = new \stdClass();
                 $subSchema->type = $tp;
                 $validator->check($value, $subSchema, $path, null);


### PR DESCRIPTION
when inheriting from TypeConstraint to change the behaviour of `validateType` (e.g. to add support for custom types), this would switch from the extended class to the base class if type is an array of types

e.g.

schema:
```json
{
    "properties": {
        "foo": {
            "type": ["null", "Custom"]
        }
    }
}
```

doc:
```json
{"foo": null}
```

Code:
```php
class CustomTypeConstraint extends JsonSchema\Constraints\TypeConstraint {
    protected function validateType($value, $type) {
        if ('Custom' === $type) {
            return someFancyValueValidation($value); // doesn't matter..
        }
        return parent::validateType($value, $type);
    }
}

$factory = new JsonSchema\Constraints\Factory;
$factory->setConstraintClass('type', CustomTypeConstraint::class);
$validator = new JsonSchema\Validator(JsonSchema\Validator::CHECK_MODE_NORMAL, new JsonSchema\Uri\UriRetriever, $factory);
$validator->check($doc, $schema);
```