### PR TITLE
Added I18n to validation messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: php
 matrix:
   fast_finish: true
   include:
-    - php: 5.3
-    - php: 5.4
     - php: 5.5
     - php: 5.6
       env: WITH_COVERAGE=true
@@ -14,8 +12,6 @@ matrix:
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
-  - printf "\n" | pecl install yaml
-
   - composer selfupdate
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" ]]; then phpenv config-rm xdebug.ini; fi
+  - printf "\n" | pecl install yaml
+
   - composer selfupdate
 
 install:

--- a/add-yaml-ext.ini
+++ b/add-yaml-ext.ini
@@ -1,1 +1,0 @@
-extension="yaml.so"

--- a/add-yaml-ext.ini
+++ b/add-yaml-ext.ini
@@ -1,0 +1,1 @@
+extension="yaml.so"

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,9 @@
         }
     }],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "robotdance/php-i18n": "0.0.7",
+        "robotdance/php-app-config": "0.0.8"
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,8 +37,8 @@
     }],
     "require": {
         "php": ">=5.3.3",
-        "robotdance/php-i18n": "0.0.7",
-        "robotdance/php-app-config": "0.0.8"
+        "robotdance/php-i18n": "0.0.8",
+        "robotdance/php-app-config": "0.0.9"
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,0 +1,1 @@
+default_locale: en_US

--- a/config/locales/en_US.yml
+++ b/config/locales/en_US.yml
@@ -1,0 +1,51 @@
+en_US:
+  constraints:
+    collection:
+      min_items: "There must be a minimum of %{minItems} in the array"
+      max_items: "There must be a maximum of %{maxItems} in the array"
+      unique_items: "There are no duplicates allowed in the array"
+      additional_items: "The item %{item}[%{index}] is not defined and the definition does not allow additional items"
+    object:
+      additional_properties: "The property %{property} is not defined and the definition does not allow additional properties"
+      property_requires_another: "The presence of the property %{property} requires that %{required} also be present"
+      pattern: "The pattern %{pattern} is invalid"
+      min_properties: "Must contain a minimum of %{count} properties"
+      max_properties: "Must contain a maximum of %{count} properties"
+    string:
+      min_length: "Must be at least %{minLength} characters long"
+      max_length: "Must be at most %{maxLength} characters long"
+      pattern: "Does not match the regex pattern %{pattern}"
+    enum:
+      element_does_not_belong: "Does not have a value in the enumeration %{enum}"
+    format:
+      date: "Invalid date %{date}, expected format YYYY-MM-DD"
+      time: "Invalid time %{time}, expected format hh:mm:ss"
+      datetime: "Invalid date-time %{datetime}, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm"
+      utcmilli: "Invalid time %{utcmilli}, expected integer of milliseconds since Epoch"
+      regex: "Invalid regex format %{regex}"
+      color: "Invalid color"
+      style: "Invalid style"
+      phone: "Invalid phone"
+      url: "Invalid URL format"
+      email: "Invalid email"
+      ipv4: "Invalid IP address"
+      ipv6: "Invalid IP address"
+      hostname: "Invalid hostname"
+    number:
+      minimum: "Must have a minimum value of %{value}"
+      exclusive_minimum: "Use of exclusiveMinimum requires presence of minimum"
+      maximum: "Must have a maximum value of %{value}"
+      exclusive_maximum: "Use of exclusiveMaximum requires presence of maximum"
+      divisible_by: "Is not divisible by %{value}"
+      multiple_by: "Must be multiple of %{value}"
+    type:
+      required: "%{actual} value found, but %{required} is required"
+    undefined:
+      required: "The property %{property} is required"
+      required_missing: "Is missing and it is required"
+      disallowed_matched: "Disallowed value was matched"
+      not_schema: "Matched a schema wich it should not"
+      failed_match_all: "Failed to match all schemas"
+      failed_match_at_least_one: "Failed to match at least one schema"
+      failed_match_one: "Failed to match exactly one schema"
+      depends_on: "%{key} depends on %{dependency} and %{dependency} is missing"

--- a/config/locales/pt_BR.yml
+++ b/config/locales/pt_BR.yml
@@ -1,0 +1,51 @@
+pt_BR:
+  constraints:
+    collection:
+      min_items: "É preciso haver um mínimo de %{minItems} items no vetor"
+      max_items: "É preciso haver um máximo de %{maxItems} item no vetor"
+      unique_items: "Não são permitidos elementos duplicados"
+      additional_items: "O item %{item}[%{index}] não está definido e o schema não permite items adicionais"
+    object:
+      additional_properties: "A propriedade %{property} não está definida e o schema não permite propriedades adicionais"
+      property_requires_another: "A presença da propriedade %{property} requer que %{required} também esteja presente"
+      pattern: "O padrão %{pattern} é inválido"
+      min_properties: "Deve conter um mínimo de %{count} propriedades"
+      max_properties: "Deve conter um máximo de %{count} propriedades"
+    string:
+      min_length: "Precisa conter no mínimo %{minLength} caracteres"
+      max_length: "Precisa conter no máximo %{maxLength} caracteres"
+      pattern: "Não corresponde ao padrão %{pattern}"
+    enum:
+      element_does_not_belong: "Não possui um valor na enumeração %{enum}"
+    format:
+      date: "Data inválida: %{date}, esperado formato YYYY-MM-DD"
+      time: "Hora inválida: %{time}, esperado formato hh:mm:ss"
+      datetime: "Data-hora inválida: %{datetime}, esperado formato YYYY-MM-DDThh:mm:ssZ ou YYYY-MM-DDThh:mm:ss+hh:mm"
+      utcmilli: "Hora em milissegundos inválida: %{utcmilli}, esperado numero inteiro de milissegundos do Unix Epoch"
+      regex: "Formato de espressão regular inválido: %{regex}"
+      color: "Cor inválida"
+      style: "Estilo inválido"
+      phone: "Telefone inválido"
+      url: "Formato de URL inválida"
+      email: "email inválido"
+      ipv4: "Endereço de IP inválido"
+      ipv6: "Endereço de IP inválido"
+      hostname: "Hostname inválido"
+    number:
+      minimum: "Precisa de um valor mínimo de %{value}"
+      exclusive_minimum: "O uso de exclusiveMinimum requer a presença de minimum"
+      maximum: "Precisa de um valor máximo de %{value}"
+      exclusive_maximum: "O uso de exclusiveMaximum requer a presença de maximum"
+      divisible_by: "Não é divisível por %{value}"
+      multiple_by: "Precisa ser múltiplo de %{value}"
+    type:
+      required: "Encontrado %{actual} porém %{required} é requerido"
+    undefined:
+      required: "A propriedade %{property} é requerida"
+      required_missing: "Não está presente e é requerido"
+      disallowed_matched: "Um valor não permitido foi encontrado"
+      not_schema: "Correspondeu a um esquema que não deveria"
+      failed_match_all: "Falhou em corresponder a todos os esquemas"
+      failed_match_at_least_one: "Falhou em corresponder a pelo menos um esquema"
+      failed_match_one: "Falhou em corresponder a exatamente um esquema"
+      depends_on: "%{key} depende de %{dependency} e %{dependency} não está presente"

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use robotdance\I18n;
+
 /**
  * The CollectionConstraint Constraints, validates an array against a given schema
  *
@@ -24,12 +26,14 @@ class CollectionConstraint extends Constraint
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
-            $this->addError($path, "There must be a minimum of " . $schema->minItems . " items in the array", 'minItems', array('minItems' => $schema->minItems,));
+            $errorMsg = I18n::t("constraints.collection.min_items", ['minItems' => $schema->minItems]);
+            $this->addError($path, $errorMsg, 'minItems', array('minItems' => $schema->minItems,));
         }
 
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
-            $this->addError($path, "There must be a maximum of " . $schema->maxItems . " items in the array", 'maxItems', array('maxItems' => $schema->maxItems,));
+            $errorMsg = I18n::t("constraints.collection.max_items", ['maxItems' => $schema->maxItems]);
+            $this->addError($path, $errorMsg, 'maxItems', array('maxItems' => $schema->maxItems,));
         }
 
         // Verify uniqueItems
@@ -39,7 +43,8 @@ class CollectionConstraint extends Constraint
                 $unique = array_map(function($e) { return var_export($e, true); }, $value);
             }
             if (count(array_unique($unique)) != count($value)) {
-                $this->addError($path, "There are no duplicates allowed in the array", 'uniqueItems');
+                $errorMsg = I18n::t("constraints.collection.unique_items");
+                $this->addError($path, $errorMsg, 'uniqueItems');
             }
         }
 
@@ -91,8 +96,9 @@ class CollectionConstraint extends Constraint
                         if ($schema->additionalItems !== false) {
                             $this->checkUndefined($v, $schema->additionalItems, $path, $k);
                         } else {
+                            $errorMsg = I18n::t("constraints.collection.additional_items", ['item' => $i, 'index' => $k]);
                             $this->addError(
-                                $path, 'The item ' . $i . '[' . $k . '] is not defined and the definition does not allow additional items', 'additionalItems', array('additionalItems' => $schema->additionalItems,));
+                                $path, $errorMsg, 'additionalItems', array('additionalItems' => $schema->additionalItems,));
                         }
                     } else {
                         // Should be valid against an empty schema

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use robotdance\I18n;
+
 /**
  * The EnumConstraint Constraints, validates an element against a given set of possibilities
  *
@@ -40,7 +42,7 @@ class EnumConstraint extends Constraint
                 }
             }
         }
-
-        $this->addError($path, "Does not have a value in the enumeration " . json_encode($schema->enum), 'enum', array('enum' => $schema->enum,));
+        $errorMsg = I18n::t("constraints.enum.element_does_not_belong", ['enum' => json_encode($schema->enum)]);
+        $this->addError($path, $errorMsg, 'enum', array('enum' => $schema->enum,));
     }
 }

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -8,7 +8,9 @@
  */
 
 namespace JsonSchema\Constraints;
+
 use JsonSchema\Rfc3339;
+use robotdance\I18n;
 
 /**
  * Validates against the "format" property
@@ -30,60 +32,70 @@ class FormatConstraint extends Constraint
         switch ($schema->format) {
             case 'date':
                 if (!$date = $this->validateDateTime($element, 'Y-m-d')) {
-                    $this->addError($path, sprintf('Invalid date %s, expected format YYYY-MM-DD', json_encode($element)), 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.date", ['date' => json_encode($element)]);
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'time':
                 if (!$this->validateDateTime($element, 'H:i:s')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected format hh:mm:ss', json_encode($element)), 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.time", ['time' => json_encode($element)]);
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'date-time':
                 if (null === Rfc3339::createFromString($element)) {
-                    $this->addError($path, sprintf('Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm', json_encode($element)), 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.datetime", ['datetime' => json_encode($element)]);
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'utc-millisec':
                 if (!$this->validateDateTime($element, 'U')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected integer of milliseconds since Epoch', json_encode($element)), 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.utcmilli", ['utcmilli' => json_encode($element)]);
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'regex':
                 if (!$this->validateRegex($element)) {
-                    $this->addError($path, 'Invalid regex format ' . $element, 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.regex", ['regex' => json_encode($element)]);
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'color':
                 if (!$this->validateColor($element)) {
-                    $this->addError($path, "Invalid color", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.color");
+                    $this->addError($path,  $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'style':
                 if (!$this->validateStyle($element)) {
-                    $this->addError($path, "Invalid style", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.style");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'phone':
                 if (!$this->validatePhone($element)) {
-                    $this->addError($path, "Invalid phone number", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.phone");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'uri':
                 if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError($path, "Invalid URL format", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.url");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'email':
                 if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)) {
+                    $errorMsg = I18n::t("constraints.format.email");
                     $this->addError($path, "Invalid email", 'format', array('format' => $schema->format,));
                 }
                 break;
@@ -91,20 +103,23 @@ class FormatConstraint extends Constraint
             case 'ip-address':
             case 'ipv4':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)) {
-                    $this->addError($path, "Invalid IP address", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.ipv4");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'ipv6':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV6)) {
-                    $this->addError($path, "Invalid IP address", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.ipv6");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 
             case 'host-name':
             case 'hostname':
                 if (!$this->validateHostname($element)) {
-                    $this->addError($path, "Invalid hostname", 'format', array('format' => $schema->format,));
+                    $errorMsg = I18n::t("constraints.format.hostname");
+                    $this->addError($path, $errorMsg, 'format', array('format' => $schema->format,));
                 }
                 break;
 

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use robotdance\I18n;
+
 /**
  * The NumberConstraint Constraints, validates an number against a given schema
  *
@@ -25,41 +27,48 @@ class NumberConstraint extends Constraint
         // Verify minimum
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
+                $errorMsg = I18n::t("constraints.number.minimum", ['value' => $schema->minimum]);
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
-                    $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'exclusiveMinimum', array('minimum' => $schema->minimum,));
+                    $this->addError($path, $errorMsg, 'exclusiveMinimum', array('minimum' => $schema->minimum,));
                 } else if ($element < $schema->minimum) {
-                    $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'minimum', array('minimum' => $schema->minimum,));
+                    $this->addError($path, $errorMsg, 'minimum', array('minimum' => $schema->minimum,));
                 }
             } else {
-                $this->addError($path, "Use of exclusiveMinimum requires presence of minimum", 'missingMinimum');
+                $errorMsg = I18n::t("constraints.number.exclusive_minimum");
+                $this->addError($path, $errorMsg, 'missingMinimum');
             }
         } else if (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'minimum', array('minimum' => $schema->minimum,));
+            $errorMsg = I18n::t("constraints.number.minimum", ['value' => $schema->minimum]);
+            $this->addError($path, $errorMsg, 'minimum', array('minimum' => $schema->minimum,));
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
+                $errorMsg = I18n::t("constraints.number.maximum", ['value' => $schema->maximum]);
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
-                    $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'exclusiveMaximum', array('maximum' => $schema->maximum,));
+                    $this->addError($path, $errorMsg, 'exclusiveMaximum', array('maximum' => $schema->maximum,));
                 } else if ($element > $schema->maximum) {
-                    $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'maximum', array('maximum' => $schema->maximum,));
+                    $this->addError($path, $errorMsg, 'maximum', array('maximum' => $schema->maximum,));
                 }
             } else {
                 $this->addError($path, "Use of exclusiveMaximum requires presence of maximum", 'missingMaximum');
             }
         } else if (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'maximum', array('maximum' => $schema->maximum,));
+            $errorMsg = I18n::t("constraints.number.maximum", ['value' => $schema->maximum]);
+            $this->addError($path, $errorMsg, 'maximum', array('maximum' => $schema->maximum,));
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError($path, "Is not divisible by " . $schema->divisibleBy, 'divisibleBy', array('divisibleBy' => $schema->divisibleBy,));
+            $errorMsg = I18n::t("constraints.number.divisible_by", ['value' => $schema->divisibleBy]);
+            $this->addError($path, $errorMsg, 'divisibleBy', array('divisibleBy' => $schema->divisibleBy,));
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError($path, "Must be a multiple of " . $schema->multipleOf, 'multipleOf', array('multipleOf' => $schema->multipleOf,));
+            $errorMsg = I18n::t("constraints.number.multiple_of", ['value' => $schema->multipleOf]);
+            $this->addError($path, $errorMsg, 'multipleOf', array('multipleOf' => $schema->multipleOf,));
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use robotdance\I18n;
+
 /**
  * The ObjectConstraint Constraints, validates an object against a given schema
  *
@@ -55,7 +57,8 @@ class ObjectConstraint extends Constraint
 
             // Validate the pattern before using it to test for matches
             if (@preg_match($delimiter. $pregex . $delimiter, '') === false) {
-                $this->addError($path, 'The pattern "' . $pregex . '" is invalid', 'pregex', array('pregex' => $pregex,));
+                $errorMsg = I18n::t("constraints.object.pattern", ['pattern' => $pregex]);
+                $this->addError($path, $errorMsg, 'pregex', array('pregex' => $pregex,));
                 continue;
             }
             foreach ($element as $i => $value) {
@@ -85,7 +88,8 @@ class ObjectConstraint extends Constraint
 
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
-                $this->addError($path, "The property " . $i . " is not defined and the definition does not allow additional properties", 'additionalProp');
+                $errorMsg = I18n::t("constraints.object.additional_properties", ['property' => $i]);
+                $this->addError($path, $errorMsg, 'additionalProp');
             }
 
             // additional properties defined
@@ -100,7 +104,8 @@ class ObjectConstraint extends Constraint
             // property requires presence of another
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
-                $this->addError($path, "The presence of the property " . $i . " requires that " . $require . " also be present", 'requires');
+                $errorMsg = I18n::t("constraints.object.property_requires_another", ['property' => $i, 'required' => $require]);
+                $this->addError($path, $errorMsg, 'requires');
             }
 
             if (!$definition) {
@@ -162,13 +167,15 @@ class ObjectConstraint extends Constraint
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
             if (count(get_object_vars($element)) < $objectDefinition->minProperties) {
+                $errorMsg = I18n::t("constraints.object.min_properties", ['count' => $objectDefinition->minProperties]);
                 $this->addError($path, "Must contain a minimum of " . $objectDefinition->minProperties . " properties", 'minProperties', array('minProperties' => $objectDefinition->minProperties,));
             }
         }
         // Verify maximum number of properties
         if (isset($objectDefinition->maxProperties) && !is_object($objectDefinition->maxProperties)) {
             if (count(get_object_vars($element)) > $objectDefinition->maxProperties) {
-                $this->addError($path, "Must contain no more than " . $objectDefinition->maxProperties . " properties", 'maxProperties', array('maxProperties' => $objectDefinition->maxProperties,));
+                $errorMsg = I18n::t("constraints.object.max_properties", ['count' => $objectDefinition->maxProperties]);
+                $this->addError($path, $errorMsg, 'maxProperties', array('maxProperties' => $objectDefinition->maxProperties,));
             }
         }
     }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Constraints;
 
+use robotdance\I18n;
+
 /**
  * The StringConstraint Constraints, validates an string against a given schema
  *
@@ -24,21 +26,24 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError($path, "Must be at most " . $schema->maxLength . " characters long", 'maxLength', array(
+            $errorMsg = I18n::t("constraints.string.max_length", ['maxLength' => $schema->maxLength]);
+            $this->addError($path, $errorMsg, 'maxLength', array(
                 'maxLength' => $schema->maxLength,
             ));
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError($path, "Must be at least " . $schema->minLength . " characters long", 'minLength', array(
+            $errorMsg = I18n::t("constraints.string.min_length", ['minLength' => $schema->minLength]);
+            $this->addError($path, $errorMsg, 'minLength', array(
                 'minLength' => $schema->minLength,
             ));
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
-            $this->addError($path, "Does not match the regex pattern " . $schema->pattern, 'pattern', array(
+            $errorMsg = I18n::t("constraints.string.pattern", ['pattern' => $schema->pattern]);
+            $this->addError($path, $errorMsg, 'pattern', array(
                 'pattern' => $schema->pattern,
             ));
         }

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;
 use UnexpectedValueException as StandardUnexpectedValueException;
+use robotdance\I18n;
 
 /**
  * The TypeConstraint Constraints, validates an element against a given type
@@ -82,7 +83,8 @@ class TypeConstraint extends Constraint
                         implode(', ', array_filter(self::$wording)))
                 );
             }
-            $this->addError($path, ucwords(gettype($value)) . " value found, but " . self::$wording[$type] . " is required", 'type');
+            $errorMsg = I18n::t("constraints.type.required", ['actual' => ucwords(gettype($value)), 'required' => self::$wording[$type]]);
+            $this->addError($path, $errorMsg, 'type');
         }
     }
 

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Uri\UriResolver;
+use robotdance\I18n;
 
 /**
  * The UndefinedConstraint Constraints
@@ -114,13 +115,15 @@ class UndefinedConstraint extends Constraint
                 // Draft 4 - Required is an array of strings - e.g. "required": ["foo", ...]
                 foreach ($schema->required as $required) {
                     if (!property_exists($value, $required)) {
-                        $this->addError((!$path) ? $required : "$path.$required", "The property " . $required . " is required", 'required');
+                        $errorMsg = I18n::t("constraints.undefined.required", ['property' => $required]);
+                        $this->addError((!$path) ? $required : "$path.$required", $errorMsg, 'required');
                     }
                 }
             } else if (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ( $schema->required && $value instanceof UndefinedConstraint) {
-                    $this->addError($path, "Is missing and it is required", 'required');
+                    $errorMsg = I18n::t("constraints.undefined.required_missing");
+                    $this->addError($path, $errorMsg, 'required');
                 }
             }
         }
@@ -140,7 +143,8 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised it must be a disallowed value
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "Disallowed value was matched", 'disallow');
+                $errorMsg = I18n::t("constraints.undefined.disallowed_matched");
+                $this->addError($path, $errorMsg, 'disallow');
             } else {
                 $this->errors = $initErrors;
             }
@@ -152,7 +156,8 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised then the instance validated against the "not" schema
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, "Matched a schema which it should not", 'not');
+                $errorMsg = I18n::t("constraints.undefined.not_schema");
+                $this->addError($path, $errorMsg, 'not');
             } else {
                 $this->errors = $initErrors;
             }
@@ -187,7 +192,8 @@ class UndefinedConstraint extends Constraint
                 $isValid = $isValid && (count($this->getErrors()) == count($initErrors));
             }
             if (!$isValid) {
-                $this->addError($path, "Failed to match all schemas", 'allOf');
+                $errorMsg = I18n::t("constraints.undefined.failed_match_all");
+                $this->addError($path, $errorMsg, 'allOf');
             }
         }
 
@@ -202,7 +208,8 @@ class UndefinedConstraint extends Constraint
                 }
             }
             if (!$isValid) {
-                $this->addError($path, "Failed to match at least one schema", 'anyOf');
+                $errorMsg = I18n::t("constraints.undefined.failed_match_at_least_one");
+                $this->addError($path, $errorMsg, 'anyOf');
             } else {
                 $this->errors = $startErrors;
             }
@@ -221,12 +228,13 @@ class UndefinedConstraint extends Constraint
                 $allErrors = array_merge($allErrors, array_values($this->getErrors()));
             }
             if ($matchedSchemas !== 1) {
+                $errorMsg = I18n::t("constraints.undefined.failed_match_one");
                 $this->addErrors(
                     array_merge(
                         $allErrors,
                         array(array(
                             'property' => $path,
-                            'message' => "Failed to match exactly one schema",
+                            'message' => $errorMsg,
                             'constraint' => 'oneOf',
                         ),),
                         $startErrors
@@ -253,13 +261,15 @@ class UndefinedConstraint extends Constraint
                 if (is_string($dependency)) {
                     // Draft 3 string is allowed - e.g. "dependencies": {"bar": "foo"}
                     if (!property_exists($value, $dependency)) {
-                        $this->addError($path, "$key depends on $dependency and $dependency is missing", 'dependencies');
+                        $errorMsg = I18n::t('constraints.undefined.depends_on', ['key' => $key, 'dependency' => $dependency]);
+                        $this->addError($path, $errorMsg, 'dependencies');
                     }
                 } else if (is_array($dependency)) {
                     // Draft 4 must be an array - e.g. "dependencies": {"bar": ["foo"]}
                     foreach ($dependency as $d) {
                         if (!property_exists($value, $d)) {
-                            $this->addError($path, "$key depends on $d and $d is missing", 'dependencies');
+                            $errorMsg = I18n::t('constraints.undefined.depends_on', ['key' => $key, 'dependency' => $d]);
+                            $this->addError($path, $errorMsg, 'dependencies');
                         }
                     }
                 } else if (is_object($dependency)) {

--- a/tests/I18n/I18nTest.php
+++ b/tests/I18n/I18nTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\I18n;
+
+use JsonSchema\Validator;
+
+class I18nTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @dataProvider getInvalidTests
+     */
+    public function testTranslation($schema, $sample, $lang, $msg)
+    {
+        \Locale::setDefault($lang);
+        $validator = new Validator();
+        $validator->check($sample, $schema);
+        $errors = $validator->getErrors();
+        $this->assertRegexp("/$msg/", $errors[0]['message']);
+    }
+
+    /**
+     * Returns a set of test scenarios for each translation test
+     * [0] schema
+     * [1] invalid sample
+     * [2] language
+     * [3] fragment of message in the language
+     */
+    public function getInvalidTests()
+    {
+        return [
+            /* minItems */
+            [(object)["id"=>"value", "type"=>"array", "minItems"=>2], [1], 'en_US', 'There must be a minimum'],
+            [(object)["id"=>"value", "type"=>"array", "minItems"=>2], [1], 'pt_BR', 'É preciso haver um mínimo'],
+            /* maxItems */
+            [(object)["id"=>"value", "type"=>"array", "maxItems"=>1], [1,2], 'en_US', 'There must be a maximum'],
+            [(object)["id"=>"value", "type"=>"array", "maxItems"=>1], [1,2], 'pt_BR', 'É preciso haver um máximo'],
+            /* uniqueItems */
+            [(object)["id"=>"value", "type"=>"array", "uniqueItems"=>true], [1,1], 'en_US', 'There are no duplicates allowed'],
+            [(object)["id"=>"value", "type"=>"array", "uniqueItems"=>true], [1,1], 'pt_BR', 'Não são permitidos elementos duplicados'],
+            /* minimum */
+            [(object)["id"=>"value", "type"=>"number", "minimum"=>10], 1, 'en_US', 'Must have a minimum'],
+            [(object)["id"=>"value", "type"=>"number", "minimum"=>10], 1, 'pt_BR', 'Precisa de um valor mínimo'],
+            /* maximum */
+            [(object)["id"=>"value", "type"=>"number", "maximum"=>10], 11, 'en_US', 'Must have a maximum'],
+            [(object)["id"=>"value", "type"=>"number", "maximum"=>10], 11, 'pt_BR', 'Precisa de um valor máximo'],
+            /* minLength */
+            [(object)["id"=>"value", "type"=>"string", "minLength"=>2], 'a', 'en_US', 'Must be at least'],
+            [(object)["id"=>"value", "type"=>"string", "minLength"=>2], 'a', 'pt_BR', 'Precisa conter no mínimo'],
+            /* maxLength */
+            [(object)["id"=>"value", "type"=>"string", "maxLength"=>2], 'abc', 'en_US', 'Must be at most'],
+            [(object)["id"=>"value", "type"=>"string", "maxLength"=>2], 'abc', 'pt_BR', 'Precisa conter no máximo'],
+            /* pattern */
+            [(object)["id"=>"value", "type"=>"string", "pattern"=>"^abc$"], 'abcd', 'en_US', 'Does not match'],
+            [(object)["id"=>"value", "type"=>"string", "pattern"=>"^abc$"], 'abcd', 'pt_BR', 'Não corresponde ao padrão'],
+        ];
+    }
+}


### PR DESCRIPTION
This PR adds I18n to validation messages, initially available in en_US and pt_BR. For additional languages, add it to `config/locales`, following the previous conventions.