### PR TITLE
Support json_decode assoc

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -76,7 +76,7 @@ class CollectionConstraint extends Constraint
                 // Reset errors if needed
                 if (isset($secondErrors) && count($secondErrors) < count($this->getErrors())) {
                     $this->errors = $secondErrors;
-                } else if (isset($secondErrors) && count($secondErrors) === count($this->getErrors())) {
+                } elseif (isset($secondErrors) && count($secondErrors) === count($this->getErrors())) {
                     $this->errors = $initErrors;
                 }
             }
@@ -102,7 +102,7 @@ class CollectionConstraint extends Constraint
             }
 
             // Treat when we have more schema definitions than values, not for empty arrays
-            if(count($value) > 0) {
+            if (count($value) > 0) {
                 for ($k = count($value); $k < count($schema->items); $k++) {
                     $this->checkUndefined(new UndefinedConstraint(), $schema->items[$k], $path, $k);
                 }

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Uri\UriRetriever;
+use JsonSchema\Validator;
 
 /**
  * The Base Constraints, all Validators should extend this class
@@ -49,8 +50,7 @@ abstract class Constraint implements ConstraintInterface
      */
     public function getUriRetriever()
     {
-        if (is_null($this->uriRetriever))
-        {
+        if (is_null($this->uriRetriever)) {
             $this->setUriRetriever(new UriRetriever);
         }
 
@@ -63,7 +63,7 @@ abstract class Constraint implements ConstraintInterface
     public function getFactory()
     {
         if (!$this->factory) {
-            $this->factory = new Factory($this->getUriRetriever());
+            $this->factory = new Factory($this->getUriRetriever(), $this->checkMode);
         }
 
         return $this->factory;
@@ -287,5 +287,15 @@ abstract class Constraint implements ConstraintInterface
         $jsonSchema = $this->uriRetriever->retrieve($uri);
         // TODO validate using schema
         return $jsonSchema;
+    }
+
+    /**
+     * Get the type check based on the set check mode.
+     *
+     * @return TypeCheck\TypeCheckInterface
+     */
+    protected function getTypeCheck()
+    {
+        return $this->getFactory()->getTypeCheck();
     }
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -8,6 +8,7 @@
  */
 
 namespace JsonSchema\Constraints;
+use JsonSchema\Validator;
 
 /**
  * The EnumConstraint Constraints, validates an element against a given set of possibilities
@@ -26,17 +27,23 @@ class EnumConstraint extends Constraint
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {
             return;
         }
+        $type = gettype($element);
 
         foreach ($schema->enum as $enum) {
-            $type = gettype($element);
+            $enumType = gettype($enum);
+            if ($this->checkMode === self::CHECK_MODE_TYPE_CAST && $type == "array" && $enumType == "object") {
+                if ((object)$element == $enum) {
+                    return;
+                }
+            }
+
             if ($type === gettype($enum)) {
                 if ($type == "object") {
-                    if ($element == $enum)
+                    if ($element == $enum) {
                         return;
-                } else {
-                    if ($element === $enum)
-                        return;
-
+                    }
+                } elseif ($element === $enum) {
+                    return;
                 }
             }
         }

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -27,13 +27,13 @@ class NumberConstraint extends Constraint
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
                     $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'exclusiveMinimum', array('minimum' => $schema->minimum,));
-                } else if ($element < $schema->minimum) {
+                } elseif ($element < $schema->minimum) {
                     $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'minimum', array('minimum' => $schema->minimum,));
                 }
             } else {
                 $this->addError($path, "Use of exclusiveMinimum requires presence of minimum", 'missingMinimum');
             }
-        } else if (isset($schema->minimum) && $element < $schema->minimum) {
+        } elseif (isset($schema->minimum) && $element < $schema->minimum) {
             $this->addError($path, "Must have a minimum value of " . $schema->minimum, 'minimum', array('minimum' => $schema->minimum,));
         }
 
@@ -42,13 +42,13 @@ class NumberConstraint extends Constraint
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
                     $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'exclusiveMaximum', array('maximum' => $schema->maximum,));
-                } else if ($element > $schema->maximum) {
+                } elseif ($element > $schema->maximum) {
                     $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'maximum', array('maximum' => $schema->maximum,));
                 }
             } else {
                 $this->addError($path, "Use of exclusiveMaximum requires presence of maximum", 'missingMaximum');
             }
-        } else if (isset($schema->maximum) && $element > $schema->maximum) {
+        } elseif (isset($schema->maximum) && $element > $schema->maximum) {
             $this->addError($path, "Must have a maximum value of " . $schema->maximum, 'maximum', array('maximum' => $schema->maximum,));
         }
 

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -20,7 +20,7 @@ class ObjectConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    function check($element, $definition = null, $path = null, $additionalProp = null, $patternProperties = null)
+    public function check($element, $definition = null, $path = null, $additionalProp = null, $patternProperties = null)
     {
         if ($element instanceof UndefinedConstraint) {
             return;
@@ -161,13 +161,13 @@ class ObjectConstraint extends Constraint
     protected function validateMinMaxConstraint($element, $objectDefinition, $path) {
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
-            if (count(get_object_vars($element)) < $objectDefinition->minProperties) {
+            if ($this->getTypeCheck()->propertyCount($element) < $objectDefinition->minProperties) {
                 $this->addError($path, "Must contain a minimum of " . $objectDefinition->minProperties . " properties", 'minProperties', array('minProperties' => $objectDefinition->minProperties,));
             }
         }
         // Verify maximum number of properties
         if (isset($objectDefinition->maxProperties) && !is_object($objectDefinition->maxProperties)) {
-            if (count(get_object_vars($element)) > $objectDefinition->maxProperties) {
+            if ($this->getTypeCheck()->propertyCount($element) > $objectDefinition->maxProperties) {
                 $this->addError($path, "Must contain no more than " . $objectDefinition->maxProperties . " properties", 'maxProperties', array('maxProperties' => $objectDefinition->maxProperties,));
             }
         }

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -27,9 +27,14 @@ class SchemaConstraint extends Constraint
         if ($schema !== null) {
             // passed schema
             $this->checkUndefined($element, $schema, '', '');
-        } elseif (property_exists($element, $this->inlineSchemaProperty)) {
+        } elseif ($this->getTypeCheck()->propertyExists($element, $this->inlineSchemaProperty)) {
+            $inlineSchema = $this->getTypeCheck()->propertyGet($element, $this->inlineSchemaProperty);
+            if (is_array($inlineSchema)) {
+                $inlineSchema = json_decode(json_encode($inlineSchema));
+            }
+
             // inline schema
-            $this->checkUndefined($element, $element->{$this->inlineSchemaProperty}, '', '');
+            $this->checkUndefined($element, $inlineSchema, '', '');
         } else {
             throw new InvalidArgumentException('no schema found to verify against');
         }

--- a/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace JsonSchema\Constraints\TypeCheck;
+
+class LooseTypeCheck implements TypeCheckInterface
+{
+    public static function isObject($value)
+    {
+        return
+            is_object($value) ||
+            (is_array($value) && (count($value) == 0 || self::isAssociativeArray($value)));
+    }
+
+    public static function isArray($value)
+    {
+        return
+            is_array($value) &&
+            (count($value) == 0 || !self::isAssociativeArray($value));
+    }
+
+    public static function propertyGet($value, $property)
+    {
+        if (is_object($value)) {
+            return $value->{$property};
+        }
+
+        return $value[$property];
+    }
+
+    public static function propertyExists($value, $property)
+    {
+        if (is_object($value)) {
+            return property_exists($value, $property);
+        }
+
+        return array_key_exists($property, $value);
+    }
+
+    public static function propertyCount($value)
+    {
+        if (is_object($value)) {
+            return count(get_object_vars($value));
+        }
+
+        return count($value);
+    }
+
+    /**
+     * Check if the provided array is associative or not
+     *
+     * @param array $arr
+     *
+     * @return bool
+     */
+    private static function isAssociativeArray($arr)
+    {
+        return (array_keys($arr) !== range(0, count($arr) - 1));
+    }
+}

--- a/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace JsonSchema\Constraints\TypeCheck;
+
+class StrictTypeCheck implements TypeCheckInterface
+{
+    public static function isObject($value)
+    {
+        return is_object($value);
+    }
+
+    public static function isArray($value)
+    {
+        return is_array($value);
+    }
+
+    public static function propertyGet($value, $property)
+    {
+        return $value->{$property};
+    }
+
+    public static function propertyExists($value, $property)
+    {
+        return property_exists($value, $property);
+    }
+
+    public static function propertyCount($value)
+    {
+        return count(get_object_vars($value));
+    }
+}

--- a/src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+++ b/src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace JsonSchema\Constraints\TypeCheck;
+
+interface TypeCheckInterface
+{
+    public static function isObject($value);
+
+    public static function isArray($value);
+
+    public static function propertyGet($value, $property);
+
+    public static function propertyExists($value, $property);
+
+    public static function propertyCount($value);
+}

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -116,12 +116,11 @@ class TypeConstraint extends Constraint
         }
 
         if ('object' === $type) {
-            return is_object($value);
-            //return ($this::CHECK_MODE_TYPE_CAST == $this->checkMode) ? is_array($value) : is_object($value);
+            return $this->getTypeCheck()->isObject($value);
         }
 
         if ('array' === $type) {
-            return is_array($value);
+            return $this->getTypeCheck()->isArray($value);
         }
 
         if ('string' === $type) {

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -9,8 +9,6 @@
 
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Validator;
-
 class AdditionalPropertiesTest extends BaseTestCase
 {
     public function getInvalidTests()
@@ -52,8 +50,7 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "prop":{"type":"string"}
                   },
                   "additionalProperties": false
-                }',
-                Validator::CHECK_MODE_TYPE_CAST
+                }'
             ),
             array(
                 '{
@@ -79,8 +76,7 @@ class AdditionalPropertiesTest extends BaseTestCase
                     "prop":{"type":"string"}
                   },
                   "additionalProperties": {"type":"string"}
-                }',
-                Validator::CHECK_MODE_TYPE_CAST
+                }'
             ),
             array(
                 '{
@@ -132,8 +128,7 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "properties":{
                     "prop":{"type":"string"}
                   }
-                }',
-                Validator::CHECK_MODE_TYPE_CAST
+                }'
             ),
             array(
                 '{

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -7,8 +7,6 @@
  */
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Validator;
-
 /**
  * Class OfPropertiesTest
  */
@@ -71,7 +69,7 @@ class OfPropertiesTest extends BaseTestCase
                   },
                   "required": ["prop1"]
                 }',
-                Validator::CHECK_MODE_NORMAL,
+                null,
                 array(
                     array(
                         "property"   => "prop2",

--- a/tests/Constraints/RequiredPropertyTest.php
+++ b/tests/Constraints/RequiredPropertyTest.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\UndefinedConstraint;
 
 class RequiredPropertyTest extends BaseTestCase
@@ -229,7 +230,8 @@ class RequiredPropertyTest extends BaseTestCase
                   "properties": {
                     "array":{"type":"array", "required": true}
                   }
-                }'
+                }',
+                Constraint::CHECK_MODE_NORMAL
             ),
             array(
                 '{

--- a/tests/Drafts/BaseDraftTestCase.php
+++ b/tests/Drafts/BaseDraftTestCase.php
@@ -21,17 +21,19 @@ abstract class BaseDraftTestCase extends BaseTestCase
         foreach ($filePaths as $path) {
             foreach (glob($path . '/*.json') as $file) {
                 $filename = basename($file);
-                if (!in_array($filename, $skippedTests)) {
-                    $suites = json_decode(file_get_contents($file));
-                    foreach ($suites as $suite) {
-                        $suiteDescription = $suite->description;
-                        foreach ($suite->tests as $test) {
-                            $testCaseDescription = $test->description;
-                            if ($isValid === $test->valid) {
-                                $tests[
-                                    $this->createDataSetPath($filename, $suiteDescription, $testCaseDescription)
-                                ] = array(json_encode($test->data), json_encode($suite->schema));
-                            }
+                if (in_array($filename, $skippedTests)) {
+                    continue;
+                }
+
+                $suites = json_decode(file_get_contents($file));
+                foreach ($suites as $suite) {
+                    $suiteDescription = $suite->description;
+                    foreach ($suite->tests as $test) {
+                        $testCaseDescription = $test->description;
+                        if ($isValid === $test->valid) {
+                            $tests[
+                                $this->createDataSetPath($filename, $suiteDescription, $testCaseDescription)
+                            ] = array(json_encode($test->data), json_encode($suite->schema));
                         }
                     }
                 }

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -8,6 +8,7 @@
  */
 
 namespace JsonSchema\Tests\Drafts;
+use JsonSchema\Constraints\Constraint;
 
 /**
  * @package JsonSchema\Tests\Drafts
@@ -23,6 +24,28 @@ class Draft3Test extends BaseDraftTestCase
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft3'),
             realpath(__DIR__ . $this->relativeTestsRoot . '/draft3/optional')
         );
+    }
+
+    public function getInvalidForAssocTests()
+    {
+        $tests = parent::getInvalidForAssocTests();
+        unset(
+            $tests['type.json / object type matches objects / an array is not an object'],
+            $tests['type.json / array type matches arrays / an object is not an array']
+        );
+
+        return $tests;
+    }
+
+    public function getValidForAssocTests()
+    {
+        $tests = parent::getValidForAssocTests();
+        unset(
+            $tests['type.json / object type matches objects / an array is not an object'],
+            $tests['type.json / array type matches arrays / an object is not an array']
+        );
+
+        return $tests;
     }
 
     /**

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -25,6 +25,28 @@ class Draft4Test extends BaseDraftTestCase
         );
     }
 
+    public function getInvalidForAssocTests()
+    {
+        $tests = parent::getInvalidForAssocTests();
+        unset(
+            $tests['type.json / object type matches objects / an array is not an object'],
+            $tests['type.json / array type matches arrays / an object is not an array']
+        );
+
+        return $tests;
+    }
+
+    public function getValidForAssocTests()
+    {
+        $tests = parent::getValidForAssocTests();
+        unset(
+            $tests['type.json / object type matches objects / an array is not an object'],
+            $tests['type.json / array type matches arrays / an object is not an array']
+        );
+
+        return $tests;
+    }
+
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | "master"
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | Since `Constraint::CHECK_MODE_TYPE_CAST` was not actively used I would say no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #267
| License       | MIT

Hi there,

I was running into the problem where `json_decode($input, true)` was not validation as I was hoping. 
To fix the problem I implemented a special `TypeCheckInterface` this will now be used to determine if something is a object, array and will do special logic to get properties etc.

I need to add some special cases where tests failed because of the array structure.

To use the `json_decode($input, true)` with the `Validator` a user must set the checkMode to `Constraint::CHECK_MODE_TYPE_CAST`.

I hope you like the PR and I'm looking forward to the comments.

Cheers,
Warnar