### PR TITLE
Updating to use more correct hostname regex. This fixes #129

### DIFF
--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -173,6 +173,7 @@ class FormatConstraint extends Constraint
 
     protected function validateHostname($host)
     {
-        return preg_match('/^[_a-z]+\.([_a-z]+\.?)+$/i', $host);
+        $hostnameRegex = '/^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$/i';
+        return preg_match($hostnameRegex, $host);
     }
 }

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -123,6 +123,9 @@ class FormatTest extends BaseTestCase
             array('::ff', 'ipv6'),
 
             array('www.example.com', 'host-name'),
+            array('3v4l.org', 'host-name'),
+            array('a-valid-host.com', 'host-name'),
+            array('localhost', 'host-name'),
 
             array('anything', '*'),
             array('unknown', '*'),
@@ -166,7 +169,8 @@ class FormatTest extends BaseTestCase
 
             array(':::ff', 'ipv6'),
 
-            array('localhost', 'host-name'),
+            array('@localhost', 'host-name'),
+            array('..nohost', 'host-name'),
 
         );
     }


### PR DESCRIPTION
Also, `localhost` is definitely a valid hostname...