### PR TITLE
some optimizations

### DIFF
--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -23,7 +23,7 @@ class Factory
      * @var SchemaStorage
      */
     protected $schemaStorage;
-   
+
     /**
      * @var UriRetriever $uriRetriever
      */
@@ -57,6 +57,11 @@ class Factory
     );
 
     /**
+     * @var array<ConstraintInterface>
+     */
+    private $instanceCache = array();
+
+    /**
      * @param SchemaStorage $schemaStorage
      * @param UriRetrieverInterface $uriRetriever
      * @param int $checkMode
@@ -78,7 +83,7 @@ class Factory
     {
         return $this->uriRetriever;
     }
-    
+
     public function getSchemaStorage()
     {
         return $this->schemaStorage;
@@ -124,12 +129,15 @@ class Factory
     public function createInstanceFor($constraintName)
     {
         if (array_key_exists($constraintName, $this->constraintMap)) {
-            return new $this->constraintMap[$constraintName](
-                $this->checkMode,
-                $this->schemaStorage,
-                $this->uriRetriever,
-                $this
-            );
+            if (!isset($this->instanceCache[$constraintName])) {
+                $this->instanceCache[$constraintName] = new $this->constraintMap[$constraintName](
+                    $this->checkMode,
+                    $this->schemaStorage,
+                    $this->uriRetriever,
+                    $this
+                );
+            }
+            return clone $this->instanceCache[$constraintName];
         }
         throw new InvalidArgumentException('Unknown constraint ' . $constraintName);
     }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -105,11 +105,6 @@ class ObjectConstraint extends Constraint
                 $this->addError($path, "The presence of the property " . $i . " requires that " . $require . " also be present", 'requires');
             }
 
-            if (!$definition) {
-                // normal property verification
-                $this->checkUndefined($value, new \stdClass(), $path, $i);
-            }
-
             $property = $this->getProperty($element, $i, new UndefinedConstraint());
             if (is_object($property)) {
                 $this->validateMinMaxConstraint(!($property instanceof UndefinedConstraint) ? $property : $element, $definition, $path);
@@ -129,7 +124,11 @@ class ObjectConstraint extends Constraint
         foreach ($objectDefinition as $i => $value) {
             $property = $this->getProperty($element, $i, $this->getFactory()->createInstanceFor('undefined'));
             $definition = $this->getProperty($objectDefinition, $i);
-            $this->checkUndefined($property, $definition, $path, $i);
+
+            if (is_object($definition)) {
+                // Undefined constraint will check for is_object() and quit if is not - so why pass it?
+                $this->checkUndefined($property, $definition, $path, $i);
+            }
         }
     }
 


### PR DESCRIPTION
Hi guys..

this PR tries to minimize the calls done by the validation. Most is quite minor, but if you're dealing with call graphs like this (check the call numbers) - even small things matter..

![call graph](https://s31.postimg.org/4fxy5knqz/02_up.png "Call graph")

I could squeeze out ~100ms out with those changes, whole request is now ~1.5s, so it saved maybe ~6-7%.. I'm still on the quest to squeeze more out, but only those were the low hanging fruits I've found..

It seems there is a certain threshold where validation is 'quite quick' - if the graph becomes quite big (like in our case); there is a continuous increase in request time. Makes sense of course.. 

There is something I commented out in this PR where I wasn't sure why it's even there, I'll comment it separately.. 