### PR TITLE
Updated to check that $ref is a string

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -98,7 +98,7 @@ class SchemaStorage
      */
     public function resolveRefSchema($refSchema)
     {
-        if (is_object($refSchema) && property_exists($refSchema, '$ref')) {
+        if (is_object($refSchema) && property_exists($refSchema, '$ref') && is_string($refSchema->{'$ref'})) {
             $newSchema = $this->resolveRef($refSchema->{'$ref'});
             $refSchema = (object) (get_object_vars($refSchema) + get_object_vars($newSchema));
             unset($refSchema->{'$ref'});


### PR DESCRIPTION
This is an issue when processing the OpenAPI/Swagger spec, where `$ref` is an object.

Example on line 315 of the OAPI spec:
```json
"$ref": {
      "type": "string"
},
```

From what I understand, the spec is a valid document, but beaks the current resolver logic.