### PR TITLE
fix(NumberConstraint): force positive value on first arg

### DIFF
--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -69,6 +69,7 @@ class NumberConstraint extends Constraint
 
     private function fmod($number1, $number2)
     {
+        $number1 = abs($number1);
         $modulus = fmod($number1, $number2);
         $precision = abs(0.0000000001);
         $diff = (float)($modulus - $number2);

--- a/tests/Constraints/NumberAndIntegerTypesTest.php
+++ b/tests/Constraints/NumberAndIntegerTypesTest.php
@@ -95,6 +95,19 @@ class NumberAndIntegerTypesTest extends BaseTestCase
                     "type": "object",
                     "properties": {
                         "number": {"type": "number"}
+
+                    }
+                }'
+            ),
+            array(
+                '{"number": -49.89}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "number": {
+                          "type": "number",
+                          "multipleOf": 0.01
+                        }
                     }
                 }'
             )


### PR DESCRIPTION
Resolves #315 - `multipleOf` is inconsistent, fails for negative numbers