### PR TITLE
Add support for  $ref on properties

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -60,7 +60,7 @@ class UndefinedConstraint extends Constraint
         if ($this->getTypeCheck()->isObject($value)) {
             $this->checkObject(
                 $value,
-                isset($schema->properties) ? $schema->properties : $schema,
+                isset($schema->properties) ? $this->schemaStorage->resolveRefSchema($schema->properties) : $schema,
                 $path,
                 isset($schema->additionalProperties) ? $schema->additionalProperties : null,
                 isset($schema->patternProperties) ? $schema->patternProperties : null

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -62,6 +62,12 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
             $schemaStorage->resolveRef("$mainSchemaPath#/properties/car/properties/wheel")
         );
 
+        // properties ref
+        $this->assertEquals(
+            $schemaStorage->resolveRef("$mainSchemaPath#/definitions/yardproperties"),
+            $schemaStorage->resolveRef("$mainSchemaPath#/properties/yard/properties")
+        );
+
         // local ref with overriding
         $this->assertNotEquals(
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house/additionalProperties"),
@@ -77,6 +83,7 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house"),
             $schemaStorage->resolveRef("$mainSchemaPath#/properties/house/properties/house")
         );
+
         $this->assertEquals(
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house"),
             $schemaStorage->resolveRef("$mainSchemaPath#/properties/house/properties/house/properties/house")
@@ -123,6 +130,13 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
                 'house' => (object) array(
                     'additionalProperties' => true,
                     '$ref' => '#/definitions/house'
+                ),
+                'yard' => (object) array(
+                    'type' => 'object',
+                    'additionalProperties' => false,
+                    'properties' => (object)[
+                        '$ref' => '#/definitions/yardproperties'
+                    ]
                 )
             ),
             'definitions' => (object) array(
@@ -143,6 +157,14 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
                         'house' => (object) array(
                             '$ref' => '#/definitions/house'
                         )
+                    )
+                ),
+                'yardproperties' => (object) array(
+                    'tree'=>(object) array(
+                        'type' => 'string'
+                    ),
+                    'pool'=>(object) array(
+                        'type' => 'string'
                     )
                 )
             )

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -134,9 +134,9 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
                 'yard' => (object) array(
                     'type' => 'object',
                     'additionalProperties' => false,
-                    'properties' => (object)[
+                    'properties' => (object) array(
                         '$ref' => '#/definitions/yardproperties'
-                    ]
+					)
                 )
             ),
             'definitions' => (object) array(


### PR DESCRIPTION
Adds support for $ref on the properties attribute. You don't often see examples of this kind of thing out there in the wild, but $ref is actually not defined by the json schema standard; it's more of a [JSON thing](https://tools.ietf.org/html/draft-pbryan-zyp-json-ref-03) , and it's very useful in situations where you want to make properties of something reusable while still controlling a custom description or name:

```
$schema = [
   "frontPhoto"=>[
       "type"=>"object",
       "description" => "Supply a nice photo of the front of the object you want to sell",
       "properties" => [
          '$ref' => '/path/to/photo.attributes.json'
       ]
   ],
  "backPhoto"=>[
       "type"=>"object",
       "description" => "See if you have a nice photo of the back of the object you want to sell. This photo is optional",
       "properties" => [
          '$ref' => '/path/to/photo.attributes.json'
       ]
   ]
];
```