### PR TITLE
[BUGFIX] Use unicode matching for patterns

### DIFF
--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -39,7 +39,7 @@ class StringConstraint extends Constraint
         }
 
         // Verify a regex pattern
-        if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#', $element)) {
+        if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#u', $element)) {
             $this->addError($path, "Does not match the regex pattern " . $schema->pattern, 'pattern', array(
                 'pattern' => $schema->pattern,
             ));

--- a/tests/Constraints/PatternTest.php
+++ b/tests/Constraints/PatternTest.php
@@ -35,7 +35,17 @@ class PatternTest extends BaseTestCase
                     },
                     "additionalProperties": false
                 }'
-            )
+            ),
+            array(
+                '{"value": "Ã¼"}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string", "pattern": "^ü$"}
+                    },
+                    "additionalProperties": false
+                }'
+            ),
         );
     }
 
@@ -72,6 +82,16 @@ class PatternTest extends BaseTestCase
                     "type": "object",
                     "properties": {
                         "value": {"type": "string", "pattern": "^a*$"}
+                    },
+                    "additionalProperties": false
+                }'
+            ),
+            array(
+                '{"value": "↓æ→"}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "value": {"type": "string", "pattern": "^↓æ.$"}
                     },
                     "additionalProperties": false
                 }'


### PR DESCRIPTION
JSON allows all unicode characters, thus the matching should work when using unicode characters.