### PR TITLE
improve validation performance of long string, number and integer arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,5 +141,7 @@ $jsonValidator->check($jsonToValidateObject, $jsonSchemaObject);
 ## Running the tests
 
 ```bash
-vendor/bin/phpunit
+composer test
+composer testOnly TestClass
+composer testOnly TestClass::testMethod
 ```

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
     },
     "scripts": {
         "test" : "vendor/bin/phpunit",
+        "testOnly" : "vendor/bin/phpunit --colors --filter",
         "coverage" : "vendor/bin/phpunit  --coverage-text"
     }
 }

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -14,19 +14,12 @@ use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Uri\UriResolver;
 use JsonSchema\Validator;
-use Prophecy\Argument;
 
 /**
  * @package JsonSchema\Tests\Constraints
  */
-abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class BaseTestCase extends VeryBaseTestCase
 {
-    /** @var object */
-    private $jsonSchemaDraft03;
-
-    /** @var object */
-    private $jsonSchemaDraft04;
-
     /**
      * @dataProvider getInvalidTests
      */
@@ -126,66 +119,5 @@ abstract class BaseTestCase extends \PHPUnit_Framework_TestCase
     public function getInvalidForAssocTests()
     {
         return $this->getInvalidTests();
-    }
-
-    /**
-     * @param object $schema
-     * @return object
-     */
-    protected function getUriRetrieverMock($schema)
-    {
-        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/JSON-Schema-Test-Suite/remotes');
-
-        $jsonSchemaDraft03 = $this->getJsonSchemaDraft03();
-        $jsonSchemaDraft04 = $this->getJsonSchemaDraft04();
-
-        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
-        $uriRetriever->retrieve('http://www.my-domain.com/schema.json')
-            ->willReturn($schema)
-            ->shouldBeCalled();
-
-        $uriRetriever->retrieve(Argument::any())
-            ->will(function ($args) use ($jsonSchemaDraft03, $jsonSchemaDraft04, $relativeTestsRoot) {
-                if ('http://json-schema.org/draft-03/schema' === $args[0]) {
-                    return $jsonSchemaDraft03;
-                } elseif ('http://json-schema.org/draft-04/schema' === $args[0]) {
-                    return $jsonSchemaDraft04;
-                } elseif (0 === strpos($args[0], 'http://localhost:1234')) {
-                    $urlParts = parse_url($args[0]);
-                    return json_decode(file_get_contents($relativeTestsRoot . $urlParts['path']));
-                } elseif (0 === strpos($args[0], 'http://www.my-domain.com')) {
-                    $urlParts = parse_url($args[0]);
-                    return json_decode(file_get_contents($relativeTestsRoot . '/folder' . $urlParts['path']));
-                }
-            });
-        return $uriRetriever->reveal();
-    }
-
-    /**
-     * @return object
-     */
-    private function getJsonSchemaDraft03()
-    {
-        if (!$this->jsonSchemaDraft03) {
-            $this->jsonSchemaDraft03 = json_decode(
-                file_get_contents(__DIR__ . '/../fixtures/json-schema-draft-03.json')
-            );
-        }
-
-        return $this->jsonSchemaDraft03;
-    }
-
-    /**
-     * @return object
-     */
-    private function getJsonSchemaDraft04()
-    {
-        if (!$this->jsonSchemaDraft04) {
-            $this->jsonSchemaDraft04 = json_decode(
-                file_get_contents(__DIR__ . '/../fixtures/json-schema-draft-04.json')
-            );
-        }
-
-        return $this->jsonSchemaDraft04;
     }
 }

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+use JsonSchema\Constraints\Factory;
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
+
+class LongArraysTest extends VeryBaseTestCase
+{
+    public function testLongStringArray()
+    {
+        $schema =
+            '{
+              "type":"object",
+              "properties":{
+                "p_array":{
+                  "type":"array",
+                  "items":{"type":"string"}
+                }
+              }
+            }';
+
+        $tmp = new \stdClass();
+        $tmp->p_array = array_map(function ($i) {
+            return "#".$i;
+        }, range(1, 100000));
+        $input = json_encode($tmp);
+
+        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
+        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
+
+        $validator = new Validator(new Factory($schemaStorage));
+        $validator->check(json_decode($input), $schema);
+        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
+    }
+
+    public function testLongNumberArray()
+    {
+        $schema =
+            '{
+              "type":"object",
+              "properties":{
+                "p_array":{
+                  "type":"array",
+                  "items":{"type":"number"}
+                }
+              }
+            }';
+
+        $tmp = new \stdClass();
+        $tmp->p_array = array_map(function ($i) {
+            return rand(1, 1000) / 1000.0;
+        }, range(1, 100000));
+        $input = json_encode($tmp);
+
+        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
+        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
+
+        $validator = new Validator(new Factory($schemaStorage));
+        $validator->check(json_decode($input), $schema);
+        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
+    }
+
+    public function testLongIntegerArray()
+    {
+        $schema =
+            '{
+              "type":"object",
+              "properties":{
+                "p_array":{
+                  "type":"array",
+                  "items":{"type":"integer"}
+                }
+              }
+            }';
+
+        $tmp = new \stdClass();
+        $tmp->p_array = array_map(function ($i) {
+            return $i;
+        }, range(1, 100000));
+        $input = json_encode($tmp);
+
+        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
+        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
+
+        $validator = new Validator(new Factory($schemaStorage));
+        $validator->check(json_decode($input), $schema);
+        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
+    }
+
+    private static function millis()
+    {
+        $mt = explode(' ', microtime());
+        return $mt[1] * 1000 + round($mt[0] * 1000);
+    }
+}

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+use Prophecy\Argument;
+
+/**
+ * @package JsonSchema\Tests\Constraints
+ */
+abstract class VeryBaseTestCase extends \PHPUnit_Framework_TestCase
+{
+    /** @var object */
+    private $jsonSchemaDraft03;
+
+    /** @var object */
+    private $jsonSchemaDraft04;
+
+    /**
+     * @param object $schema
+     * @return object
+     */
+    protected function getUriRetrieverMock($schema)
+    {
+        $relativeTestsRoot = realpath(__DIR__ . '/../../vendor/json-schema/JSON-Schema-Test-Suite/remotes');
+
+        $jsonSchemaDraft03 = $this->getJsonSchemaDraft03();
+        $jsonSchemaDraft04 = $this->getJsonSchemaDraft04();
+
+        $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
+        $uriRetriever->retrieve('http://www.my-domain.com/schema.json')
+            ->willReturn($schema)
+            ->shouldBeCalled();
+
+        $uriRetriever->retrieve(Argument::any())
+            ->will(function ($args) use ($jsonSchemaDraft03, $jsonSchemaDraft04, $relativeTestsRoot) {
+                if ('http://json-schema.org/draft-03/schema' === $args[0]) {
+                    return $jsonSchemaDraft03;
+                } elseif ('http://json-schema.org/draft-04/schema' === $args[0]) {
+                    return $jsonSchemaDraft04;
+                } elseif (0 === strpos($args[0], 'http://localhost:1234')) {
+                    $urlParts = parse_url($args[0]);
+                    return json_decode(file_get_contents($relativeTestsRoot . $urlParts['path']));
+                } elseif (0 === strpos($args[0], 'http://www.my-domain.com')) {
+                    $urlParts = parse_url($args[0]);
+                    return json_decode(file_get_contents($relativeTestsRoot . '/folder' . $urlParts['path']));
+                }
+            });
+        return $uriRetriever->reveal();
+    }
+
+    /**
+     * @return object
+     */
+    private function getJsonSchemaDraft03()
+    {
+        if (!$this->jsonSchemaDraft03) {
+            $this->jsonSchemaDraft03 = json_decode(
+                file_get_contents(__DIR__ . '/../fixtures/json-schema-draft-03.json')
+            );
+        }
+
+        return $this->jsonSchemaDraft03;
+    }
+
+    /**
+     * @return object
+     */
+    private function getJsonSchemaDraft04()
+    {
+        if (!$this->jsonSchemaDraft04) {
+            $this->jsonSchemaDraft04 = json_decode(
+                file_get_contents(__DIR__ . '/../fixtures/json-schema-draft-04.json')
+            );
+        }
+
+        return $this->jsonSchemaDraft04;
+    }
+}


### PR DESCRIPTION
Validation is unexpectedly slow for large uniform arrays with simple json schema like below:
```
{
  "type": "array",
    "items": {
      "type": "string"
    }
}
```
For 100K string arrays validation lasts for about 2000 ms.
With such a workaround, the performance gain is 3X.
It can be improved twice more with lazy $path calculation on validation error.

Please note, the proposed fix is not the 'true' way - major refactoring with api changes is required,
it rather pinpoints the problem.