### PR TITLE
Fix regex for Rfc3339 validation

### DIFF
--- a/src/JsonSchema/Rfc3339.php
+++ b/src/JsonSchema/Rfc3339.php
@@ -4,7 +4,7 @@ namespace JsonSchema;
 
 class Rfc3339
 {
-    const REGEX = '/(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))/';
+    const REGEX = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))$/';
 
     /**
      * Try creating a DateTime instance

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -150,6 +150,9 @@ class FormatTest extends BaseTestCase
             array('00:00:60', 'time'),
             array('25:00:00', 'time'),
 
+
+            array('invalid_value_2000-05-01T12:12:12Z', 'date-time'),
+            array('2000-05-01T12:12:12Z_invalid_value', 'date-time'),
             array('1999-1-11T00:00:00Z', 'date-time'),
             array('1999-01-11T00:00:00+100', 'date-time'),
             array('1999-01-11T00:00:00+1:00', 'date-time'),


### PR DESCRIPTION
This is fixing a `date-time` validation problem where an invalid datetime string is still considered valid if it starts or ends with invalid chars (see the tests for a more clear example).