### PR TITLE
Add option to apply default values from the schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,40 @@ $validator->coerce($request, $schema);
 // equivalent to $validator->validate($data, $schema, Constraint::CHECK_MODE_COERCE_TYPES);
 ```
 
+### Default values
+
+If your schema contains default values, you can have these automatically applied during validation:
+
+```php
+<?php
+
+use JsonSchema\Validator;
+use JsonSchema\Constraints\Constraint;
+
+$request = (object)[
+    'refundAmount'=>17
+];
+
+$validator = new Validator();
+
+$validator->validate(
+    $request,
+    (object)[
+        "type"=>"object",
+        "properties"=>(object)[
+            "processRefund"=>(object)[
+                "type"=>"boolean",
+                "default"=>true
+            ]
+        ]
+    ],
+    Constraint::CHECK_MODE_APPLY_DEFAULTS
+); //validates, and sets defaults for missing properties
+
+is_bool($request->processRefund); // true
+$request->processRefund; // true
+```
+
 ### With inline references
 
 ```php
@@ -152,9 +186,11 @@ third argument to `Validator::validate()`, or can be provided as the third argum
 | `Constraint::CHECK_MODE_NORMAL` | Validate in 'normal' mode - this is the default |
 | `Constraint::CHECK_MODE_TYPE_CAST` | Enable fuzzy type checking for associative arrays and objects |
 | `Constraint::CHECK_MODE_COERCE_TYPES` | Convert data types to match the schema where possible |
+| `Constraint::CHECK_MODE_APPLY_DEFAULTS` | Apply default values from the schema if not set |
 | `Constraint::CHECK_MODE_EXCEPTIONS` | Throw an exception immediately if validation fails |
 
-Please note that using `Constraint::CHECK_MODE_COERCE_TYPES` will modify your original data.
+Please note that using `Constraint::CHECK_MODE_COERCE_TYPES` or `Constraint::CHECK_MODE_APPLY_DEFAULTS`
+will modify your original data.
 
 ## Running the tests
 

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -15,6 +15,7 @@ use JsonSchema\SchemaStorage;
 use JsonSchema\SchemaStorageInterface;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\UriRetrieverInterface;
+use JsonSchema\Constraints\Constraint;
 
 /**
  * Factory for centralize constraint initialization.

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -9,13 +9,13 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Exception\InvalidConfigException;
 use JsonSchema\SchemaStorage;
 use JsonSchema\SchemaStorageInterface;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\UriRetrieverInterface;
-use JsonSchema\Constraints\Constraint;
 
 /**
  * Factory for centralize constraint initialization.

--- a/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
@@ -36,7 +36,6 @@ class LooseTypeCheck implements TypeCheckInterface
         }
     }
 
-
     public static function propertyExists($value, $property)
     {
         if (is_object($value)) {

--- a/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php
@@ -27,6 +27,16 @@ class LooseTypeCheck implements TypeCheckInterface
         return $value[$property];
     }
 
+    public static function propertySet(&$value, $property, $data)
+    {
+        if (is_object($value)) {
+            $value->{$property} = $data;
+        } else {
+            $value[$property] = $data;
+        }
+    }
+
+
     public static function propertyExists($value, $property)
     {
         if (is_object($value)) {

--- a/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
@@ -19,6 +19,11 @@ class StrictTypeCheck implements TypeCheckInterface
         return $value->{$property};
     }
 
+    public static function propertySet(&$value, $property, $data)
+    {
+        $value->{$property} = $data;
+    }
+
     public static function propertyExists($value, $property)
     {
         return property_exists($value, $property);

--- a/src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
+++ b/src/JsonSchema/Constraints/TypeCheck/TypeCheckInterface.php
@@ -10,6 +10,8 @@ interface TypeCheckInterface
 
     public static function propertyGet($value, $property);
 
+    public static function propertySet(&$value, $property, $data);
+
     public static function propertyExists($value, $property);
 
     public static function propertyCount($value);

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -147,7 +147,7 @@ class UndefinedConstraint extends Constraint
                         }
                     }
                 }
-            } elseif (($value instanceof UndefinedConstraint || $value === null) && isset($schema->default)) {
+            } elseif (($value instanceof self || $value === null) && isset($schema->default)) {
                 // $value is a leaf, not a container - apply the default directly
                 $value = is_object($schema->default) ? clone $schema->default : $schema->default;
             }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Uri\UriResolver;
 
@@ -57,7 +58,9 @@ class UndefinedConstraint extends Constraint
         }
 
         // check object
-        if ($this->getTypeCheck()->isObject($value)) {
+        if (LooseTypeCheck::isObject($value)) { // object processing should always be run on assoc arrays,
+                                                // so use LooseTypeCheck here even if CHECK_MODE_TYPE_CAST
+                                                // is not set (i.e. don't use $this->getTypeCheck() here).
             $this->checkObject(
                 $value,
                 isset($schema->properties) ? $this->factory->getSchemaStorage()->resolveRefSchema($schema->properties) : $schema,
@@ -104,6 +107,37 @@ class UndefinedConstraint extends Constraint
                 }
             } else {
                 $this->checkUndefined($value, $schema->extends, $path, $i);
+            }
+        }
+
+        // Apply default values from schema
+        if ($this->factory->getConfig(self::CHECK_MODE_APPLY_DEFAULTS)) {
+            if ($this->getTypeCheck()->isObject($value) && isset($schema->properties)) {
+                // $value is an object, so apply default properties if defined
+                foreach ($schema->properties as $i => $propertyDefinition) {
+                    if (!$this->getTypeCheck()->propertyExists($value, $i) && isset($propertyDefinition->default)) {
+                        $this->getTypeCheck()->propertySet($value, $i, $propertyDefinition->default);
+                    }
+                }
+            } elseif ($this->getTypeCheck()->isArray($value)) {
+                if (isset($schema->properties)) {
+                    // $value is an array, but default properties are defined, so treat as assoc
+                    foreach ($schema->properties as $i => $propertyDefinition) {
+                        if (!isset($value[$i]) && isset($propertyDefinition->default)) {
+                            $value[$i] = $propertyDefinition->default;
+                        }
+                    }
+                } elseif (isset($schema->items)) {
+                    // $value is an array, and default items are defined - treat as plain array
+                    foreach ($schema->items as $i => $itemDefinition) {
+                        if (!isset($value[$i]) && isset($itemDefinition->default)) {
+                            $value[$i] = $itemDefinition->default;
+                        }
+                    }
+                }
+            } elseif (($value instanceof UndefinedConstraint || $value === null) && isset($schema->default)) {
+                // $value is a leaf, not a container - apply the default directly
+                $value = $schema->default;
             }
         }
 

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -116,7 +116,11 @@ class UndefinedConstraint extends Constraint
                 // $value is an object, so apply default properties if defined
                 foreach ($schema->properties as $i => $propertyDefinition) {
                     if (!$this->getTypeCheck()->propertyExists($value, $i) && isset($propertyDefinition->default)) {
-                        $this->getTypeCheck()->propertySet($value, $i, $propertyDefinition->default);
+                        if (is_object($propertyDefinition->default)) {
+                            $this->getTypeCheck()->propertySet($value, $i, clone $propertyDefinition->default);
+                        } else {
+                            $this->getTypeCheck()->propertySet($value, $i, $propertyDefinition->default);
+                        }
                     }
                 }
             } elseif ($this->getTypeCheck()->isArray($value)) {
@@ -124,20 +128,28 @@ class UndefinedConstraint extends Constraint
                     // $value is an array, but default properties are defined, so treat as assoc
                     foreach ($schema->properties as $i => $propertyDefinition) {
                         if (!isset($value[$i]) && isset($propertyDefinition->default)) {
-                            $value[$i] = $propertyDefinition->default;
+                            if (is_object($propertyDefinition->default)) {
+                                $value[$i] = clone $propertyDefinition->default;
+                            } else {
+                                $value[$i] = $propertyDefinition->default;
+                            }
                         }
                     }
                 } elseif (isset($schema->items)) {
                     // $value is an array, and default items are defined - treat as plain array
                     foreach ($schema->items as $i => $itemDefinition) {
                         if (!isset($value[$i]) && isset($itemDefinition->default)) {
-                            $value[$i] = $itemDefinition->default;
+                            if (is_object($itemDefinition->default)) {
+                                $value[$i] = clone $itemDefinition->default;
+                            } else {
+                                $value[$i] = $itemDefinition->default;
+                            }
                         }
                     }
                 }
             } elseif (($value instanceof UndefinedConstraint || $value === null) && isset($schema->default)) {
                 // $value is a leaf, not a container - apply the default directly
-                $value = $schema->default;
+                $value = is_object($schema->default) ? clone $schema->default : $schema->default;
             }
         }
 

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -34,11 +34,6 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"properties":{"propertyTwo":{"default":"valueTwo"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
-            array(// fulfil required property with a default value
-                '{"propertyOne":"valueOne"}',
-                '{"properties":{"propertyTwo":{"required":true,"default":"valueTwo"}}}',
-                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
-            ),
             array(// default value for sub-property
                 '{"propertyOne":{}}',
                 '{"properties":{"propertyOne":{"properties":{"propertyTwo":{"default":"valueTwo"}}}}}',
@@ -68,11 +63,6 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
-            ),
-            array(//default value is required
-                '{"propertyOne":"valueOne"}',
-                '{"properties":{"propertyTwo":{"default":"valueTwo","required":true}}}',
-                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
             array(//default item value for an array
                 '["valueOne"]',

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -87,6 +87,16 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"type":"string"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
+            ),
+            array(// default property value is an object
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":{}}}}',
+                '{"propertyOne":"valueOne","propertyTwo":{}}'
+            ),
+            array(// default item value is an object
+                '[]',
+                '{"type":"array","items":[{"default":{}}]}',
+                '[{}]'
             )
         );
     }
@@ -134,6 +144,21 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $input = json_decode($input, true);
         $factory = new Factory(null, null, Constraint::CHECK_MODE_APPLY_DEFAULTS);
         self::testValidCases($input, $schema, $expectOutput, new Validator($factory));
+
+    }
+
+    public function testNoModificationViaReferences()
+    {
+        $input = json_decode('');
+        $schema = jsoN_decode('{"default":{"propertyOne":"valueOne"}}');
+
+        $validator = new Validator();
+        $validator->validate($input, $schema, Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_APPLY_DEFAULTS);
+
+        $this->assertEquals('{"propertyOne":"valueOne"}', json_encode($input));
+
+        $input->propertyOne = "valueTwo";
+        $this->assertEquals("valueOne", $schema->default->propertyOne);
 
     }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -8,10 +8,11 @@
  */
 
 namespace JsonSchema\Tests\Constraints;
-use JsonSchema\SchemaStorage;
-use JsonSchema\Validator;
+
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
 
 class DefaultPropertiesTest extends VeryBaseTestCase
 {
@@ -144,21 +145,19 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $input = json_decode($input, true);
         $factory = new Factory(null, null, Constraint::CHECK_MODE_APPLY_DEFAULTS);
         self::testValidCases($input, $schema, $expectOutput, new Validator($factory));
-
     }
 
     public function testNoModificationViaReferences()
     {
         $input = json_decode('');
-        $schema = jsoN_decode('{"default":{"propertyOne":"valueOne"}}');
+        $schema = json_decode('{"default":{"propertyOne":"valueOne"}}');
 
         $validator = new Validator();
         $validator->validate($input, $schema, Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_APPLY_DEFAULTS);
 
         $this->assertEquals('{"propertyOne":"valueOne"}', json_encode($input));
 
-        $input->propertyOne = "valueTwo";
-        $this->assertEquals("valueOne", $schema->default->propertyOne);
-
+        $input->propertyOne = 'valueTwo';
+        $this->assertEquals('valueOne', $schema->default->propertyOne);
     }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+use JsonSchema\SchemaStorage;
+use JsonSchema\Validator;
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Constraints\Factory;
+
+class DefaultPropertiesTest extends VeryBaseTestCase
+{
+    public function getValidTests()
+    {
+        return array(
+            array(// default value for entire object
+                '',
+                '{"default":"valueOne"}',
+                '"valueOne"'
+            ),
+            array(// default value in an empty object
+                '{}',
+                '{"properties":{"propertyOne":{"default":"valueOne"}}}',
+                '{"propertyOne":"valueOne"}'
+            ),
+            array(// default value for top-level property
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":"valueTwo"}}}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(// fulfil required property with a default value
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"required":true,"default":"valueTwo"}}}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(// default value for sub-property
+                '{"propertyOne":{}}',
+                '{"properties":{"propertyOne":{"properties":{"propertyTwo":{"default":"valueTwo"}}}}}',
+                '{"propertyOne":{"propertyTwo":"valueTwo"}}'
+            ),
+            array(// default value for sub-property with sibling
+                '{"propertyOne":{"propertyTwo":"valueTwo"}}',
+                '{"properties":{"propertyOne":{"properties":{"propertyThree":{"default":"valueThree"}}}}}',
+                '{"propertyOne":{"propertyTwo":"valueTwo","propertyThree":"valueThree"}}'
+            ),
+            array(// default value for top-level property with type check
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":"valueTwo","type":"string"}}}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(// default value for top-level property with v3 required check
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":"valueTwo","required":"true"}}}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(// default value for top-level property with v4 required check
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":"valueTwo"}},"required":["propertyTwo"]}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(//default value for an already set property
+                '{"propertyOne":"alreadySetValueOne"}',
+                '{"properties":{"propertyOne":{"default":"valueOne"}}}',
+                '{"propertyOne":"alreadySetValueOne"}'
+            ),
+            array(//default value is required
+                '{"propertyOne":"valueOne"}',
+                '{"properties":{"propertyTwo":{"default":"valueTwo","required":true}}}',
+                '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
+            ),
+            array(//default item value for an array
+                '["valueOne"]',
+                '{"type":"array","items":[{},{"type":"string","default":"valueTwo"}]}',
+                '["valueOne","valueTwo"]'
+            ),
+            array(//default item value for an empty array
+                '[]',
+                '{"type":"array","items":[{"type":"string","default":"valueOne"}]}',
+                '["valueOne"]'
+            ),
+            array(//property without a default available
+                '{"propertyOne":"alreadySetValueOne"}',
+                '{"properties":{"propertyOne":{"type":"string"}}}',
+                '{"propertyOne":"alreadySetValueOne"}'
+            )
+        );
+    }
+
+    /**
+     * @dataProvider getValidTests
+     */
+    public function testValidCases($input, $schema, $expectOutput = null, $validator = null)
+    {
+        if (is_string($input)) {
+            $inputDecoded = json_decode($input);
+        } else {
+            $inputDecoded = $input;
+        }
+
+        if ($validator === null) {
+            $factory = new Factory(null, null, Constraint::CHECK_MODE_APPLY_DEFAULTS);
+            $validator = new Validator($factory);
+        }
+        $validator->validate($inputDecoded, json_decode($schema));
+
+        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
+
+        if ($expectOutput !== null) {
+            $this->assertEquals($expectOutput, json_encode($inputDecoded));
+        }
+    }
+
+    /**
+     * @dataProvider getValidTests
+     */
+    public function testValidCasesUsingAssoc($input, $schema, $expectOutput = null)
+    {
+        $input = json_decode($input, true);
+
+        $factory = new Factory(null, null, Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_APPLY_DEFAULTS);
+        self::testValidCases($input, $schema, $expectOutput, new Validator($factory));
+    }
+
+    /**
+     * @dataProvider getValidTests
+     */
+    public function testValidCasesUsingAssocWithoutTypeCast($input, $schema, $expectOutput = null)
+    {
+        $input = json_decode($input, true);
+        $factory = new Factory(null, null, Constraint::CHECK_MODE_APPLY_DEFAULTS);
+        self::testValidCases($input, $schema, $expectOutput, new Validator($factory));
+
+    }
+}

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -9,8 +9,8 @@
 
 namespace JsonSchema\Tests\Constraints;
 
-use JsonSchema\Constraints\TypeConstraint;
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
+use JsonSchema\Constraints\TypeConstraint;
 
 /**
  * Class TypeTest

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\TypeConstraint;
+use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 
 /**
  * Class TypeTest
@@ -49,6 +50,19 @@ class TypeTest extends \PHPUnit_Framework_TestCase
         $constraint = new TypeConstraint();
         $constraint->check($value, (object) array('type' => $type));
         $this->assertTypeConstraintError(ucwords($label) . " value found, but $wording is required", $constraint);
+    }
+
+    /**
+     * Test uncovered areas of the loose type checker
+     */
+    public function testLooseTypeChecking()
+    {
+        $v = new \StdClass();
+        $v->property = 'dataOne';
+        LooseTypeCheck::propertySet($v, 'property', 'dataTwo');
+        $this->assertEquals('dataTwo', $v->property);
+        $this->assertEquals('dataTwo', LooseTypeCheck::propertyGet($v, 'property'));
+        $this->assertEquals(1, LooseTypeCheck::propertyCount($v));
     }
 
     /**


### PR DESCRIPTION
For cases when the object being validated does not define a property, but that property has a default value in the schema, set the property value to the default. This PR has been rebased on PR #351.