### PR TITLE
Fixed regex for Content-Type header parsing

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/Curl.php
+++ b/src/JsonSchema/Uri/Retrievers/Curl.php
@@ -68,7 +68,7 @@ class Curl extends AbstractRetriever
      */
     protected function fetchContentType($response)
     {
-        if (0 < preg_match("/Content-Type:(\V*)/ims", $response, $match)) {
+        if (0 < preg_match("/Content-Type:([^;]*)/ims", $response, $match)) {
             $this->contentType = trim($match[1]);
 
             return true;

--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -79,7 +79,7 @@ class FileGetContents extends AbstractRetriever
      */
     protected static function getContentTypeMatchInHeader($header)
     {
-        if (0 < preg_match("/Content-Type:(\V*)/ims", $header, $match)) {
+        if (0 < preg_match("/Content-Type:([^;]*)/ims", $header, $match)) {
             return trim($match[1]);
         }
 


### PR DESCRIPTION
Server can return Content-Type header with charset property. That throws exception when JsonSchema\Uri\UriRetriever::confirmMediaType is called.