### PR TITLE
Add new config option, refactor coerce feature to use this, and simplify the public API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,4 +28,4 @@ install:
   - travis_retry composer install --no-interaction --prefer-dist
 
 script:
-  - if [[ "$WITH_COVERAGE" == "true" ]]; then composer coverage; else composer test; fi
+  - if [[ "$WITH_COVERAGE" == "true" ]]; then ./vendor/bin/phpunit --coverage-text; else composer test; fi

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Constraints;
+
+use JsonSchema\Entity\JsonPointer;
+
+/**
+ * A more basic constraint definition - used for the public
+ * interface to avoid exposing library internals.
+ */
+class BaseConstraint
+{
+    /**
+     * @var array Errors
+     */
+    protected $errors = array();
+
+    /**
+     * @var Factory
+     */
+    protected $factory;
+
+    /**
+     * @param Factory $factory
+     */
+    public function __construct(Factory $factory = null)
+    {
+        $this->factory = $factory ? : new Factory();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addError(JsonPointer $path = null, $message, $constraint = '', array $more = null)
+    {
+        $error = array(
+            'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
+            'pointer' => ltrim(strval($path ?: new JsonPointer('')), '#'),
+            'message' => $message,
+            'constraint' => $constraint,
+        );
+
+        if (is_array($more) && count($more) > 0)
+        {
+            $error += $more;
+        }
+
+        $this->errors[] = $error;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function addErrors(array $errors)
+    {
+        if ($errors) {
+            $this->errors = array_merge($this->errors, $errors);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getErrors()
+    {
+        return $this->errors;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function isValid()
+    {
+        return !$this->getErrors();
+    }
+
+    /**
+     * Clears any reported errors.  Should be used between
+     * multiple validation checks.
+     */
+    public function reset()
+    {
+        $this->errors = array();
+    }
+}

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -40,7 +40,7 @@ interface ConstraintInterface
      * @param string           $constraint the constraint/rule that is broken, e.g.: 'minLength'
      * @param array            $more more array elements to add to the error
      */
-    public function addError(JsonPointer $path = null, $message, $constraint='', array $more=null);
+    public function addError(JsonPointer $path = null, $message, $constraint='', array $more = null);
 
     /**
      * checks if the validator has not raised errors
@@ -59,5 +59,5 @@ interface ConstraintInterface
      * @param mixed            $i
      * @throws \JsonSchema\Exception\ExceptionInterface
      */
-    public function check($value, $schema = null, JsonPointer $path = null, $i = null);
+    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null);
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -21,7 +21,7 @@ class EnumConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Only validate enum if the attribute exists
         if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {
@@ -31,7 +31,7 @@ class EnumConstraint extends Constraint
 
         foreach ($schema->enum as $enum) {
             $enumType = gettype($enum);
-            if (($this->factory->getCheckMode() & self::CHECK_MODE_TYPE_CAST) && $type == "array" && $enumType == "object") {
+            if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type == "array" && $enumType == "object") {
                 if ((object)$element == $enum) {
                     return;
                 }

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Exception\InvalidArgumentException;
+use JsonSchema\Exception\InvalidConfigException;
 use JsonSchema\SchemaStorage;
 use JsonSchema\SchemaStorageInterface;
 use JsonSchema\Uri\UriRetriever;
@@ -33,7 +34,7 @@ class Factory
     /**
      * @var int
      */
-    private $checkMode;
+    private $checkMode = Constraint::CHECK_MODE_NORMAL;
 
     /**
      * @var TypeCheck\TypeCheckInterface[]
@@ -54,8 +55,7 @@ class Factory
         'enum' => 'JsonSchema\Constraints\EnumConstraint',
         'format' => 'JsonSchema\Constraints\FormatConstraint',
         'schema' => 'JsonSchema\Constraints\SchemaConstraint',
-        'validator' => 'JsonSchema\Validator',
-        'coercer' => 'JsonSchema\Coerce'
+        'validator' => 'JsonSchema\Validator'
     );
 
     /**
@@ -73,9 +73,56 @@ class Factory
         UriRetrieverInterface $uriRetriever = null,
         $checkMode = Constraint::CHECK_MODE_NORMAL
     ) {
+        // set provided config options
+        $this->setConfig($checkMode);
+
         $this->uriRetriever = $uriRetriever ?: new UriRetriever;
         $this->schemaStorage = $schemaStorage ?: new SchemaStorage($this->uriRetriever);
+    }
+
+    /**
+     * Set config values
+     *
+     * @param int $checkMode Set checkMode options - does not preserve existing flags
+     */
+    public function setConfig($checkMode = Constraint::CHECK_MODE_NORMAL)
+    {
         $this->checkMode = $checkMode;
+    }
+
+    /**
+     * Enable checkMode flags
+     *
+     * @param int $options
+     */
+    public function addConfig($options)
+    {
+        $this->checkMode |= $options;
+    }
+
+    /**
+     * Disable checkMode flags
+     *
+     * @param int $options
+     */
+    public function removeConfig($options)
+    {
+        $this->checkMode &= ~$options;
+    }
+
+    /**
+     * Get checkMode option
+     *
+     * @param int $options Options to get, if null then return entire bitmask
+     *
+     * @return int
+     */
+    public function getConfig($options = null)
+    {
+        if ($options === null) {
+            return $this->checkMode;
+        }
+        return ($this->checkMode & $options);
     }
 
     /**
@@ -139,13 +186,5 @@ class Factory
         }
 
         return clone $this->instanceCache[$constraintName];
-    }
-
-    /**
-     * @return int
-     */
-    public function getCheckMode()
-    {
-        return $this->checkMode;
     }
 }

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -23,7 +23,7 @@ class FormatConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
         if (!isset($schema->format)) {
             return;

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -22,7 +22,7 @@ class NumberConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify minimum
         if (isset($schema->exclusiveMinimum)) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -22,20 +22,7 @@ class ObjectConstraint extends Constraint
 	/**
 	 * {@inheritDoc}
 	 */
-	public function check($element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null)
-	{
-		$this->_check($element, $definition, $path, $additionalProp, $patternProperties);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	public function coerce(&$element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null)
-	{
-		$this->_check($element, $definition, $path, $additionalProp, $patternProperties, true);
-	}
-
-	protected function _check(&$element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null, $coerce = false)
+	public function check(&$element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null)
     {
         if ($element instanceof UndefinedConstraint) {
             return;
@@ -48,7 +35,7 @@ class ObjectConstraint extends Constraint
 
         if ($definition) {
             // validate the definition properties
-            $this->validateDefinition($element, $definition, $path, $coerce);
+            $this->validateDefinition($element, $definition, $path);
         }
 
         // additional the element properties
@@ -132,9 +119,8 @@ class ObjectConstraint extends Constraint
      * @param \stdClass         $element          Element to validate
      * @param \stdClass         $objectDefinition ObjectConstraint definition
      * @param JsonPointer|null  $path             Path?
-	 * @param boolean           $coerce           Whether to coerce strings to expected types or not
      */
-    public function validateDefinition(&$element, $objectDefinition = null, JsonPointer $path = null, $coerce = false)
+    public function validateDefinition(&$element, $objectDefinition = null, JsonPointer $path = null)
     {
         $undefinedConstraint = $this->factory->createInstanceFor('undefined');
 
@@ -144,7 +130,7 @@ class ObjectConstraint extends Constraint
 
             if (is_object($definition)) {
                 // Undefined constraint will check for is_object() and quit if is not - so why pass it?
-                $this->checkUndefined($property, $definition, $path, $i, $coerce);
+                $this->checkUndefined($property, $definition, $path, $i);
             }
         }
     }

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -23,15 +23,10 @@ class SchemaConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
-    {
-        $this->_check($element, $schema, $path, $i);
-    }
-
-    protected function _check(&$element, $schema = null, JsonPointer $path = null, $i = null, $coerce = false){
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null){
         if ($schema !== null) {
             // passed schema
-            $this->checkUndefined($element, $schema, $path, $i, $coerce);
+            $this->checkUndefined($element, $schema, $path, $i);
         } elseif ($this->getTypeCheck()->propertyExists($element, $this->inlineSchemaProperty)) {
             $inlineSchema = $this->getTypeCheck()->propertyGet($element, $this->inlineSchemaProperty);
             if (is_array($inlineSchema)) {
@@ -42,10 +37,5 @@ class SchemaConstraint extends Constraint
         } else {
             throw new InvalidArgumentException('no schema found to verify against');
         }
-    }
-
-    public function coerce(&$element, $schema = null, JsonPointer $path = null, $i = null)
-    {
-        $this->_check($element, $schema, $path, $i, true);
     }
 }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -22,7 +22,7 @@ class StringConstraint extends Constraint
     /**
      * {@inheritDoc}
      */
-    public function check($element, $schema = null, JsonPointer $path = null, $i = null)
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -20,18 +20,10 @@ use JsonSchema\Entity\JsonPointer;
  */
 class UndefinedConstraint extends Constraint
 {
-	/**
-	 * {@inheritDoc}
-	 */
-	public function check($value, $schema = null, JsonPointer $path = null, $i = null){
-		$this->_check($value, $schema, $path, $i);
-	}
-
-	public function coerce(&$value, $schema = null, JsonPointer $path = null, $i = null){
-		$this->_check($value, $schema, $path, $i, true);
-	}
-
-    protected function _check(&$value, $schema = null, JsonPointer $path = null, $i = null, $coerce = false)
+    /**
+     * {@inheritDoc}
+     */
+    public function check(&$value, $schema = null, JsonPointer $path = null, $i = null)
     {
         if (is_null($schema) || !is_object($schema)) {
             return;
@@ -40,13 +32,13 @@ class UndefinedConstraint extends Constraint
         $path = $this->incrementPath($path ?: new JsonPointer(''), $i);
 
         // check special properties
-        $this->validateCommonProperties($value, $schema, $path, $i, $coerce);
+        $this->validateCommonProperties($value, $schema, $path, $i);
 
         // check allOf, anyOf, and oneOf properties
-        $this->validateOfProperties($value, $schema, $path, '', $coerce);
+        $this->validateOfProperties($value, $schema, $path, '');
 
         // check known types
-        $this->validateTypes($value, $schema, $path, $i, $coerce);
+        $this->validateTypes($value, $schema, $path, $i);
     }
 
     /**
@@ -56,13 +48,12 @@ class UndefinedConstraint extends Constraint
      * @param mixed       $schema
      * @param JsonPointer $path
      * @param string      $i
-     * @param boolean     $coerce
      */
-    public function validateTypes(&$value, $schema = null, JsonPointer $path, $i = null, $coerce = false)
+    public function validateTypes(&$value, $schema = null, JsonPointer $path, $i = null)
     {
         // check array
         if ($this->getTypeCheck()->isArray($value)) {
-            $this->checkArray($value, $schema, $path, $i, $coerce);
+            $this->checkArray($value, $schema, $path, $i);
         }
 
         // check object
@@ -72,14 +63,13 @@ class UndefinedConstraint extends Constraint
                 isset($schema->properties) ? $this->factory->getSchemaStorage()->resolveRefSchema($schema->properties) : $schema,
                 $path,
                 isset($schema->additionalProperties) ? $schema->additionalProperties : null,
-                isset($schema->patternProperties) ? $schema->patternProperties : null,
-				$coerce
+                isset($schema->patternProperties) ? $schema->patternProperties : null
             );
         }
 
         // check string
         if (is_string($value)) {
-            $this->checkString($value, $schema, $path, $i, $coerce);
+            $this->checkString($value, $schema, $path, $i);
         }
 
         // check numeric
@@ -100,9 +90,8 @@ class UndefinedConstraint extends Constraint
      * @param mixed       $schema
      * @param JsonPointer $path
      * @param string      $i
-	 * @param boolean     $coerce
      */
-    protected function validateCommonProperties(&$value, $schema = null, JsonPointer $path, $i = "", $coerce=false)
+    protected function validateCommonProperties(&$value, $schema = null, JsonPointer $path, $i = "")
     {
         // if it extends another schema, it must pass that schema as well
         if (isset($schema->extends)) {
@@ -111,10 +100,10 @@ class UndefinedConstraint extends Constraint
             }
             if (is_array($schema->extends)) {
                 foreach ($schema->extends as $extends) {
-                    $this->checkUndefined($value, $extends, $path, $i, $coerce);
+                    $this->checkUndefined($value, $extends, $path, $i);
                 }
             } else {
-                $this->checkUndefined($value, $schema->extends, $path, $i, $coerce);
+                $this->checkUndefined($value, $schema->extends, $path, $i);
             }
         }
 
@@ -141,7 +130,7 @@ class UndefinedConstraint extends Constraint
 
         // Verify type
         if (!($value instanceof UndefinedConstraint)) {
-            $this->checkType($value, $schema, $path, $i, $coerce);
+            $this->checkType($value, $schema, $path, $i);
         }
 
         // Verify disallowed items
@@ -162,7 +151,7 @@ class UndefinedConstraint extends Constraint
 
         if (isset($schema->not)) {
             $initErrors = $this->getErrors();
-            $this->checkUndefined($value, $schema->not, $path, $i, $coerce);
+            $this->checkUndefined($value, $schema->not, $path, $i);
 
             // if no new errors were raised then the instance validated against the "not" schema
             if (count($this->getErrors()) == count($initErrors)) {
@@ -185,9 +174,8 @@ class UndefinedConstraint extends Constraint
      * @param mixed       $schema
      * @param JsonPointer $path
      * @param string      $i
-	 * @param boolean     $coerce
      */
-    protected function validateOfProperties(&$value, $schema, JsonPointer $path, $i = "", $coerce = false)
+    protected function validateOfProperties(&$value, $schema, JsonPointer $path, $i = "")
     {
         // Verify type
         if ($value instanceof UndefinedConstraint) {
@@ -198,7 +186,7 @@ class UndefinedConstraint extends Constraint
             $isValid = true;
             foreach ($schema->allOf as $allOf) {
                 $initErrors = $this->getErrors();
-                $this->checkUndefined($value, $allOf, $path, $i, $coerce);
+                $this->checkUndefined($value, $allOf, $path, $i);
                 $isValid = $isValid && (count($this->getErrors()) == count($initErrors));
             }
             if (!$isValid) {
@@ -211,7 +199,7 @@ class UndefinedConstraint extends Constraint
             $startErrors = $this->getErrors();
             foreach ($schema->anyOf as $anyOf) {
                 $initErrors = $this->getErrors();
-                $this->checkUndefined($value, $anyOf, $path, $i, $coerce);
+                $this->checkUndefined($value, $anyOf, $path, $i);
                 if ($isValid = (count($this->getErrors()) == count($initErrors))) {
                     break;
                 }
@@ -229,7 +217,7 @@ class UndefinedConstraint extends Constraint
             $startErrors = $this->getErrors();
             foreach ($schema->oneOf as $oneOf) {
                 $this->errors = array();
-                $this->checkUndefined($value, $oneOf, $path, $i, $coerce);
+                $this->checkUndefined($value, $oneOf, $path, $i);
                 if (count($this->getErrors()) == 0) {
                     $matchedSchemas++;
                 }

--- a/src/JsonSchema/Exception/InvalidConfigException.php
+++ b/src/JsonSchema/Exception/InvalidConfigException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Exception;
+
+/**
+ * Wrapper for the ResourceNotFoundException
+ */
+class InvalidConfigException extends RuntimeException
+{
+}

--- a/tests/Constraints/ArraysTest.php
+++ b/tests/Constraints/ArraysTest.php
@@ -150,6 +150,22 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
+            ),
+            array( // test more schema items than array items
+                '{"data": [1, 2]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                        "type": "array",
+                            "items": [
+                                {"type": "number"},
+                                {"type": "number"},
+                                {"type": "number"}
+                            ]
+                        }
+                    }
+                }'
             )
         );
     }

--- a/tests/Constraints/BaseTestCase.php
+++ b/tests/Constraints/BaseTestCase.php
@@ -31,7 +31,8 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $validator->check(json_decode($input), $schema);
+        $checkValue = json_decode($input);
+        $validator->validate($checkValue, $schema);
 
         if (array() !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(),true));
@@ -53,7 +54,8 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $validator->check(json_decode($input, true), $schema);
+        $checkValue = json_decode($input, true);
+        $validator->validate($checkValue, $schema);
 
         if (array() !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
@@ -70,7 +72,8 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $validator->check(json_decode($input), $schema);
+        $checkValue = json_decode($input);
+        $validator->validate($checkValue, $schema);
 
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
@@ -91,7 +94,7 @@ abstract class BaseTestCase extends VeryBaseTestCase
         $value = json_decode($input, true);
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
 
-        $validator->check($value, $schema);
+        $validator->validate($value, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -22,7 +22,7 @@ class CoerciveTest extends BasicTypesTest
      */
     public function testValidCoerceCasesUsingAssoc($input, $schema)
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST;
+        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
 
         $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
@@ -31,7 +31,7 @@ class CoerciveTest extends BasicTypesTest
 
         $value = json_decode($input, true);
 
-        $validator->coerce($value, $schema);
+        $validator->validate($value, $schema, $checkMode);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 
@@ -40,7 +40,7 @@ class CoerciveTest extends BasicTypesTest
      */
     public function testValidCoerceCases($input, $schema, $errors = array())
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST;
+        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
 
         $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
@@ -52,7 +52,7 @@ class CoerciveTest extends BasicTypesTest
         $this->assertTrue(gettype($value->integer) == "string");
         $this->assertTrue(gettype($value->boolean) == "string");
 
-        $validator->coerce($value, $schema);
+        $validator->validate($value, $schema, $checkMode);
 
         $this->assertTrue(gettype($value->number) == "double");
         $this->assertTrue(gettype($value->integer) == "integer");
@@ -81,14 +81,14 @@ class CoerciveTest extends BasicTypesTest
      */
     public function testInvalidCoerceCases($input, $schema, $errors = array())
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST;
+        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
 
         $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
         $value = json_decode($input);
-        $validator->coerce($value, $schema);
+        $validator->validate($value, $schema, $checkMode);
 
         if (array() !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
@@ -101,14 +101,14 @@ class CoerciveTest extends BasicTypesTest
      */
     public function testInvalidCoerceCasesUsingAssoc($input, $schema, $errors = array())
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST;
+        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
 
         $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
         $value = json_decode($input, true);
-        $validator->coerce($value, $schema);
+        $validator->validate($value, $schema, $checkMode);
 
         if (array() !== $errors) {
             $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -26,7 +26,7 @@ class MyBadConstraint {}
  * @package JsonSchema\Tests\Constraints
  */
 class MyStringConstraint extends Constraint {
-  public function check($value, $schema = null, JsonPointer $path = null, $i = null){}
+  public function check(&$value, $schema = null, JsonPointer $path = null, $i = null){}
 }
 
 class FactoryTest extends TestCase
@@ -69,7 +69,6 @@ class FactoryTest extends TestCase
             array('enum', 'JsonSchema\Constraints\EnumConstraint'),
             array('format', 'JsonSchema\Constraints\FormatConstraint'),
             array('schema', 'JsonSchema\Constraints\SchemaConstraint'),
-            array('validator', 'JsonSchema\Validator'),
         );
     }
 
@@ -113,5 +112,33 @@ class FactoryTest extends TestCase
       $constraint = $this->factory->createInstanceFor('string');
       $this->assertInstanceOf('JsonSchema\Tests\Constraints\MyStringConstraint', $constraint);
       $this->assertInstanceOf('JsonSchema\Constraints\ConstraintInterface', $constraint);
+    }
+
+    public function testCheckMode()
+    {
+        $f = new Factory();
+
+        // test default value
+        $this->assertEquals(Constraint::CHECK_MODE_NORMAL, $f->getConfig());
+
+        // test overriding config
+        $f->setConfig(Constraint::CHECK_MODE_COERCE_TYPES);
+        $this->assertEquals(Constraint::CHECK_MODE_COERCE_TYPES, $f->getConfig());
+
+        // test adding config
+        $f->addConfig(Constraint::CHECK_MODE_NORMAL);
+        $this->assertEquals(Constraint::CHECK_MODE_NORMAL | Constraint::CHECK_MODE_COERCE_TYPES, $f->getConfig());
+
+        // test getting filtered config
+        $this->assertEquals(Constraint::CHECK_MODE_NORMAL, $f->getConfig(Constraint::CHECK_MODE_NORMAL));
+
+        // test removing config
+        $f->removeConfig(Constraint::CHECK_MODE_COERCE_TYPES);
+        $this->assertEquals(Constraint::CHECK_MODE_NORMAL, $f->getConfig());
+
+        // test resetting to defaults
+        $f->setConfig(Constraint::CHECK_MODE_COERCE_TYPES | Constraint::CHECK_MODE_TYPE_CAST);
+        $f->setConfig();
+        $this->assertEquals(Constraint::CHECK_MODE_NORMAL, $f->getConfig());
     }
 }

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -23,7 +23,8 @@ class FormatTest extends BaseTestCase
         $validator = new FormatConstraint();
         $schema = new \stdClass;
 
-        $validator->check('10', $schema);
+        $checkValue = 10;
+        $validator->check($checkValue, $schema);
         $this->assertEmpty($validator->getErrors());
     }
 
@@ -34,15 +35,18 @@ class FormatTest extends BaseTestCase
         $schema->format = 'regex';
 
         $validator->reset();
-        $validator->check('\d+', $schema);
+        $checkValue = '\d+';
+        $validator->check($checkValue, $schema);
         $this->assertEmpty($validator->getErrors());
 
         $validator->reset();
-        $validator->check('^(abc]', $schema);
+        $checkValue = '^(abc]';
+        $validator->check($checkValue, $schema);
         $this->assertCount(1, $validator->getErrors());
 
         $validator->reset();
-        $validator->check('^猡猡獛$', $schema);
+        $checkValue = '^猡猡獛$';
+        $validator->check($checkValue, $schema);
         $this->assertEmpty($validator->getErrors());
     }
 

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -38,7 +38,8 @@ class LongArraysTest extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage));
-        $validator->check(json_decode($input), $schema);
+        $checkValue = json_decode($input);
+        $validator->check($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 
@@ -65,7 +66,8 @@ class LongArraysTest extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage));
-        $validator->check(json_decode($input), $schema);
+        $checkValue = json_decode($input);
+        $validator->check($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 
@@ -92,7 +94,8 @@ class LongArraysTest extends VeryBaseTestCase
         $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
 
         $validator = new Validator(new Factory($schemaStorage));
-        $validator->check(json_decode($input), $schema);
+        $checkValue = json_decode($input);
+        $validator->check($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -79,7 +79,8 @@ class PointerTest extends \PHPUnit_Framework_TestCase
         );
 
         $validator = new Validator();
-        $validator->check(json_decode(json_encode($value)), json_decode(json_encode($schema)));
+        $checkValue = json_decode(json_encode($value));
+        $validator->check($checkValue, json_decode(json_encode($schema)));
 
         $this->assertEquals(
             array(

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use \JsonSchema\Validator;
+
 class SelfDefinedSchemaTest extends BaseTestCase
 {
     public function getInvalidTests()
@@ -59,5 +61,12 @@ class SelfDefinedSchemaTest extends BaseTestCase
                 ''
             )
         );
+    }
+
+    public function testInvalidArgumentException()
+    {
+        $v = new Validator();
+        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $v->check(json_decode('{}'), json_decode(''));
     }
 }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -270,7 +270,7 @@ EOF;
     {
         $retrieverMock = $this->getRetrieverMock($schema);
 
-        $factory = new \ReflectionProperty('JsonSchema\Constraints\Constraint', 'factory');
+        $factory = new \ReflectionProperty('JsonSchema\Constraints\BaseConstraint', 'factory');
         $factory->setAccessible(true);
         $factory = $factory->getValue($this->validator);
 


### PR DESCRIPTION
## Why
 * The current API isn't particularly good at exposing new functionality to users...
 * ...and I want to add new functionality (PR #349 and PR #354) and expose it in a sane way.
 * Passing `$coerce` all over the stack is risky - it's easy to lose track of it when making other changes.
 * The current design mandates exposing internal method arguments (`$path` and `$i`) to users.

## Changes
 * Split the Constraint class to make Validator independent from it
 * Add Validator::validate() as the main entry point
 * Turn Validator::coerce() and Validator::check() into aliases
 * Add Factory::setConfig(), getConfig(), addConfig() & removeConfig()
 * Make type-coercion a checkMode option, don't pass $coerce everywhere
 * Add some extra tests