### PR TITLE
Add composer scripts for php-cs-fixer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,11 @@ matrix:
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
   - composer selfupdate
+  - if [[ "$TRAVIS_PHP_VERSION" = "hhvm" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" ]]; then ./vendor/bin/phpunit --coverage-text; else composer test; fi
-  - if [[ "$WITH_PHPCSFIXER" == "true" ]]; then composer require friendsofphp/php-cs-fixer:^2.1 && mkdir -p $HOME/.phpcsfixer && vendor/bin/php-cs-fixer fix --cache-file "$HOME/.phpcsfixer/.php_cs.cache" --dry-run --diff --verbose; fi
+  - if [[ "$WITH_PHPCSFIXER" == "true" ]]; then mkdir -p $HOME/.phpcsfixer && vendor/bin/php-cs-fixer fix --cache-file "$HOME/.phpcsfixer/.php_cs.cache" --dry-run --diff --verbose; fi

--- a/README.md
+++ b/README.md
@@ -195,7 +195,9 @@ will modify your original data.
 ## Running the tests
 
 ```bash
-composer test
-composer testOnly TestClass
-composer testOnly TestClass::testMethod
+composer test                            # run all unit tests
+composer testOnly TestClass              # run specific unit test class
+composer testOnly TestClass::testMethod  # run specific unit test method
+composer style-check                     # check code style for errors
+composer style-fix                       # automatically fix code style errors
 ```

--- a/composer.json
+++ b/composer.json
@@ -41,6 +41,7 @@
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.22",
+        "friendsofphp/php-cs-fixer": "^2.1",
         "phpdocumentor/phpdocumentor": "~2"
     },
     "autoload": {
@@ -58,6 +59,8 @@
     "scripts": {
         "test" : "vendor/bin/phpunit",
         "testOnly" : "vendor/bin/phpunit --colors --filter",
-        "coverage" : "vendor/bin/phpunit --coverage-text"
+        "coverage" : "vendor/bin/phpunit --coverage-text",
+        "style-check" : "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix" : "vendor/bin/php-cs-fixer fix --verbose"
     }
 }


### PR DESCRIPTION
## What
 * Add php-cs-fixer to require-dev
 * Add `style-check` and `style-fix` scripts to composer

## Why
 * To make style checks & fixes easy (currently, php-cs-fixer must be manually fetched and run)
 * To encourage users to run these checks locally first rather than relying on travis integration to flag errors