### PR TITLE
[BUGFIX] Fix relative-path case where first segment contains a colon

### DIFF
--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -90,7 +90,7 @@ class FormatConstraint extends Constraint
                         $validURL = filter_var('scheme://host' . $element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE);
                     } elseif (strlen($element)) { // relative-path reference
                         $pathParts = explode('/', $element, 2);
-                        if ($pathParts[0][0] !== '.' && strpos($pathParts[0], ':') !== false) {
+                        if (strpos($pathParts[0], ':') !== false) {
                             $validURL = null;
                         } else {
                             $validURL = filter_var('scheme://host/' . $element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE);

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -126,7 +126,10 @@ class FormatTest extends BaseTestCase
             array('http://bluebox.org', 'uri'),
             array('//bluebox.org', 'uri'),
             array('/absolutePathReference/', 'uri'),
+            array('./relativePathReference/', 'uri'),
+            array('./relative:PathReference/', 'uri'),
             array('relativePathReference/', 'uri'),
+            array('relative/Path:Reference/', 'uri'),
 
             array('info@something.edu', 'email'),
 
@@ -176,6 +179,7 @@ class FormatTest extends BaseTestCase
             array('1 123 4424', 'phone'),
 
             array('htt:/bluebox.org', 'uri'),
+            array('.relative:path/reference/', 'uri'),
             array('', 'uri'),
 
             array('info@somewhere', 'email'),


### PR DESCRIPTION
Resolves minor issue with previous bugfix #358:
 * The first segment of a relative-path reference may not contain a colon
 * The previous bugfix allowed colons in the first segment if it started with a '.'