### PR TITLE
centralize errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,8 @@
         }
     }],
     "require": {
-        "php": ">=5.3.3"
+        "php": ">=5.3.3",
+        "marc-mabe/php-enum":"2.3.1"
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",

--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -95,6 +95,10 @@ class ConstraintError extends \MabeEnum\Enum
             self::UNIQUE_ITEMS => 'There are no duplicates allowed in the array'
         );
 
-        return isset($messages[$name]) ? $messages[$name] : "Unknown Error: $name";
+        if (!isset($messages[$name])) {
+            throw new InvalidArgumentException('Missing error message for ' . $name);
+        }
+
+        return $messages[$name];
     }
 }

--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace JsonSchema;
+
+class ConstraintError extends \MabeEnum\Enum
+{
+    const ADDITIONAL_ITEMS = 'additionalItems';
+    const ADDITIONAL_PROPERTIES = 'additionalProp';
+    const ALL_OF = 'allOf';
+    const ANY_OF = 'anyOf';
+    const DEPENDENCIES = 'dependencies';
+    const DISALLOW = 'disallow';
+    const DIVISIBLE_BY = 'divisibleBy';
+    const ENUM = 'enum';
+    const EXCLUSIVE_MINIMUM = 'exclusiveMinimum';
+    const EXCLUSIVE_MAXIMUM = 'exclusiveMaximum';
+    const FORMAT_COLOR = 'colorFormat';
+    const FORMAT_DATE = 'dateFormat';
+    const FORMAT_DATE_TIME = 'dateTimeFormat';
+    const FORMAT_DATE_UTC = 'dateUtcFormat';
+    const FORMAT_EMAIL = 'emailFormat';
+    const FORMAT_HOSTNAME = 'styleHostName';
+    const FORMAT_IP = 'ipFormat';
+    const FORMAT_PHONE = 'phoneFormat';
+    const FORMAT_REGEX= 'regexFormat';
+    const FORMAT_STYLE = 'styleFormat';
+    const FORMAT_TIME = 'timeFormat';
+    const FORMAT_URL = 'urlFormat';
+    const LENGTH_MAX = 'maxLength';
+    const LENGTH_MIN = 'minLength';
+    const MAXIMUM = 'maximum';
+    const MIN_ITEMS = 'minItems';
+    const MINIMUM = 'minimum';
+    const MISSING_MAXIMUM = 'missingMaximum';
+    const MISSING_MINIMUM = 'missingMinimum';
+    const MAX_ITEMS = 'maxItems';
+    const MULTIPLE_OF = 'multipleOf';
+    const NOT = 'not';
+    const ONE_OF = 'oneOf';
+    const REQUIRED = 'required';
+    const REQUIRED_D3 = 'selfRequired';
+    const REQUIRES = 'requires';
+    const PATTERN = 'pattern';
+    const PREGEX_INVALID = 'pregrex';
+    const PROPERTIES_MIN = 'minProperties';
+    const PROPERTIES_MAX = 'maxProperties';
+    const TYPE = 'type';
+    const UNIQUE_ITEMS = 'uniqueItems';
+
+    public function getMessage()
+    {
+        $name = $this->getValue();
+        static $messages = array(
+            self::ADDITIONAL_ITEMS => 'The item %s[%s] is not defined and the definition does not allow additional items',
+            self::ADDITIONAL_PROPERTIES => 'The property %s is not defined and the definition does not allow additional properties',
+            self::ALL_OF => 'Failed to match all schemas',
+            self::ANY_OF => 'Failed to match at least one schema',
+            self::DEPENDENCIES => '%s depends on %s, which is missing',
+            self::DISALLOW => 'Disallowed value was matched',
+            self::DIVISIBLE_BY => 'Is not divisible by %d',
+            self::ENUM => 'Does not have a value in the enumeration %s',
+            self::EXCLUSIVE_MINIMUM => 'Must have a minimum value greater than %d',
+            self::EXCLUSIVE_MAXIMUM => 'Must have a maximum value less than %d',
+            self::FORMAT_COLOR => 'Invalid color',
+            self::FORMAT_DATE => 'Invalid date %s, expected format YYYY-MM-DD',
+            self::FORMAT_DATE_TIME => 'Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm',
+            self::FORMAT_DATE_UTC => 'Invalid time %s, expected integer of milliseconds since Epoch',
+            self::FORMAT_EMAIL => 'Invalid email',
+            self::FORMAT_HOSTNAME => 'Invalid hostname',
+            self::FORMAT_IP => 'Invalid IP address',
+            self::FORMAT_PHONE => 'Invalid phone number',
+            self::FORMAT_REGEX=> 'Invalid regex format %s',
+            self::FORMAT_STYLE => 'Invalid style',
+            self::FORMAT_TIME => 'Invalid time %s, expected format hh:mm:ss',
+            self::FORMAT_URL => 'Invalid URL format',
+            self::LENGTH_MAX => 'Must be at most %d characters long',
+            self::LENGTH_MIN => 'Must be at least %d characters long',
+            self::MAX_ITEMS => 'There must be a maximum of %d items in the array',
+            self::MAXIMUM => 'Must have a maximum value less than or equal to %d',
+            self::MIN_ITEMS => 'There must be a minimum of %d items in the array',
+            self::MINIMUM => 'Must have a minimum value greater than or equal to %d',
+            self::MISSING_MAXIMUM => 'Use of exclusiveMaximum requires presence of maximum',
+            self::MISSING_MINIMUM => 'Use of exclusiveMinimum requires presence of minimum',
+            self::MULTIPLE_OF => 'Must be a multiple of %d',
+            self::NOT => 'Matched a schema which it should not',
+            self::ONE_OF => 'Failed to match exactly one schema',
+            self::REQUIRED => 'The property %s is required',
+            self::REQUIRED_D3 => 'Is missing and it is required',
+            self::REQUIRES => 'The presence of the property %s requires that %s also be present',
+            self::PATTERN => 'Does not match the regex pattern %s',
+            self::PREGEX_INVALID => 'The pattern %s is invalid',
+            self::PROPERTIES_MIN => 'Must contain a minimum of %d properties',
+            self::PROPERTIES_MAX => 'Must contain no more than %d properties',
+            self::TYPE => '%s value found, but %s is required',
+            self::UNIQUE_ITEMS => 'There are no duplicates allowed in the array'
+        );
+
+        return isset($messages[$name]) ? $messages[$name] : "Unknown Error: $name";
+    }
+}

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -37,7 +37,7 @@ class BaseConstraint
         $this->factory = $factory ?: new Factory();
     }
 
-    public function addError(JsonPointer $path = null, ConstraintError $constraint = null, array $more = array())
+    public function addError(ConstraintError $constraint, JsonPointer $path = null, array $more = array())
     {
         $message = $constraint ? $constraint->getMessage() : '';
         $name = $constraint ? $constraint->getValue() : '';

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -49,15 +49,14 @@ class BaseConstraint
 
                 return json_encode($val);
             }, array_values($more)))),
-            'constraint' => $constraint ? $constraint->getValue() : '',
+            'constraint' => array(
+                'name' => $constraint ? $constraint->getValue() : '',
+                'params' => $more
+            )
         );
 
         if ($this->factory->getConfig(Constraint::CHECK_MODE_EXCEPTIONS)) {
             throw new ValidationException(sprintf('Error validating %s: %s', $error['pointer'], $error['message']));
-        }
-
-        if (is_array($more) && count($more) > 0) {
-            $error += $more;
         }
 
         $this->errors[] = $error;

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -39,10 +39,12 @@ class BaseConstraint
 
     public function addError(JsonPointer $path = null, ConstraintError $constraint = null, array $more = array())
     {
+        $message = $constraint ? $constraint->getMessage() : '';
+        $name = $constraint ? $constraint->getValue() : '';
         $error = array(
             'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
             'pointer' => ltrim(strval($path ?: new JsonPointer('')), '#'),
-            'message' => ucfirst(vsprintf($constraint->getMessage(), array_map(function ($val) {
+            'message' => ucfirst(vsprintf($message, array_map(function ($val) {
                 if (is_scalar($val)) {
                     return $val;
                 }
@@ -50,7 +52,7 @@ class BaseConstraint
                 return json_encode($val);
             }, array_values($more)))),
             'constraint' => array(
-                'name' => $constraint ? $constraint->getValue() : '',
+                'name' => $name,
                 'params' => $more
             )
         );

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\ValidationException;
 
@@ -36,13 +37,19 @@ class BaseConstraint
         $this->factory = $factory ?: new Factory();
     }
 
-    public function addError(JsonPointer $path = null, $message, $constraint = '', array $more = null)
+    public function addError(JsonPointer $path = null, ConstraintError $constraint = null, array $more = array())
     {
         $error = array(
             'property' => $this->convertJsonPointerIntoPropertyPath($path ?: new JsonPointer('')),
             'pointer' => ltrim(strval($path ?: new JsonPointer('')), '#'),
-            'message' => $message,
-            'constraint' => $constraint,
+            'message' => ucfirst(vsprintf($constraint->getMessage(), array_map(function ($val) {
+                if (is_scalar($val)) {
+                    return $val;
+                }
+
+                return json_encode($val);
+            }, array_values($more)))),
+            'constraint' => $constraint ? $constraint->getValue() : '',
         );
 
         if ($this->factory->getConfig(Constraint::CHECK_MODE_EXCEPTIONS)) {

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
 /**
@@ -26,12 +27,12 @@ class CollectionConstraint extends Constraint
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
-            $this->addError($path, 'There must be a minimum of ' . $schema->minItems . ' items in the array', 'minItems', array('minItems' => $schema->minItems));
+            $this->addError($path, ConstraintError::MIN_ITEMS(), array('minItems' => $schema->minItems));
         }
 
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
-            $this->addError($path, 'There must be a maximum of ' . $schema->maxItems . ' items in the array', 'maxItems', array('maxItems' => $schema->maxItems));
+            $this->addError($path, ConstraintError::MAX_ITEMS(), array('maxItems' => $schema->maxItems));
         }
 
         // Verify uniqueItems
@@ -43,7 +44,7 @@ class CollectionConstraint extends Constraint
                 }, $value);
             }
             if (count(array_unique($unique)) != count($value)) {
-                $this->addError($path, 'There are no duplicates allowed in the array', 'uniqueItems');
+                $this->addError($path, ConstraintError::UNIQUE_ITEMS());
             }
         }
 
@@ -124,7 +125,12 @@ class CollectionConstraint extends Constraint
                             $this->checkUndefined($v, $schema->additionalItems, $path, $k);
                         } else {
                             $this->addError(
-                                $path, 'The item ' . $i . '[' . $k . '] is not defined and the definition does not allow additional items', 'additionalItems', array('additionalItems' => $schema->additionalItems));
+                                $path, ConstraintError::ADDITIONAL_ITEMS(), array(
+                                    'item' => $i,
+                                    'property' => $k,
+                                    'additionalItems' => $schema->additionalItems
+                                )
+                            );
                         }
                     } else {
                         // Should be valid against an empty schema

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -27,12 +27,12 @@ class CollectionConstraint extends Constraint
     {
         // Verify minItems
         if (isset($schema->minItems) && count($value) < $schema->minItems) {
-            $this->addError($path, ConstraintError::MIN_ITEMS(), array('minItems' => $schema->minItems));
+            $this->addError(ConstraintError::MIN_ITEMS(), $path, array('minItems' => $schema->minItems));
         }
 
         // Verify maxItems
         if (isset($schema->maxItems) && count($value) > $schema->maxItems) {
-            $this->addError($path, ConstraintError::MAX_ITEMS(), array('maxItems' => $schema->maxItems));
+            $this->addError(ConstraintError::MAX_ITEMS(), $path, array('maxItems' => $schema->maxItems));
         }
 
         // Verify uniqueItems
@@ -44,7 +44,7 @@ class CollectionConstraint extends Constraint
                 }, $value);
             }
             if (count(array_unique($unique)) != count($value)) {
-                $this->addError($path, ConstraintError::UNIQUE_ITEMS());
+                $this->addError(ConstraintError::UNIQUE_ITEMS(), $path);
             }
         }
 
@@ -125,7 +125,9 @@ class CollectionConstraint extends Constraint
                             $this->checkUndefined($v, $schema->additionalItems, $path, $k);
                         } else {
                             $this->addError(
-                                $path, ConstraintError::ADDITIONAL_ITEMS(), array(
+                                ConstraintError::ADDITIONAL_ITEMS(),
+                                $path,
+                                array(
                                     'item' => $i,
                                     'property' => $k,
                                     'additionalItems' => $schema->additionalItems

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -36,11 +36,11 @@ interface ConstraintInterface
     /**
      * adds an error
      *
-     * @param JsonPointer |null    $path
-     * @param ConstraintError|null $constraint the constraint/rule that is broken, e.g.: ConstraintErrors::LENGTH_MIN()
-     * @param array                $more       more array elements to add to the error
+     * @param ConstraintError   $constraint the constraint/rule that is broken, e.g.: ConstraintErrors::LENGTH_MIN()
+     * @param JsonPointer |null $path
+     * @param array             $more       more array elements to add to the error
      */
-    public function addError(JsonPointer $path = null, ConstraintError $constraint = null, array $more = array());
+    public function addError(ConstraintError $constraint, JsonPointer $path = null, array $more = array());
 
     /**
      * checks if the validator has not raised errors

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -36,7 +36,7 @@ interface ConstraintInterface
     /**
      * adds an error
      *
-     * @param JsonPointer|null     $path
+     * @param JsonPointer |null    $path
      * @param ConstraintError|null $constraint the constraint/rule that is broken, e.g.: ConstraintErrors::LENGTH_MIN()
      * @param array                $more       more array elements to add to the error
      */

--- a/src/JsonSchema/Constraints/ConstraintInterface.php
+++ b/src/JsonSchema/Constraints/ConstraintInterface.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
 /**
@@ -35,12 +36,11 @@ interface ConstraintInterface
     /**
      * adds an error
      *
-     * @param JsonPointer|null $path
-     * @param string           $message
-     * @param string           $constraint the constraint/rule that is broken, e.g.: 'minLength'
-     * @param array            $more       more array elements to add to the error
+     * @param JsonPointer|null     $path
+     * @param ConstraintError|null $constraint the constraint/rule that is broken, e.g.: ConstraintErrors::LENGTH_MIN()
+     * @param array                $more       more array elements to add to the error
      */
-    public function addError(JsonPointer $path = null, $message, $constraint='', array $more = null);
+    public function addError(JsonPointer $path = null, ConstraintError $constraint = null, array $more = array());
 
     /**
      * checks if the validator has not raised errors

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -50,6 +50,6 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, ConstraintError::ENUM(), array('enum' => $schema->enum));
+        $this->addError(ConstraintError::ENUM(), $path, array('enum' => $schema->enum));
     }
 }

--- a/src/JsonSchema/Constraints/EnumConstraint.php
+++ b/src/JsonSchema/Constraints/EnumConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
 /**
@@ -49,6 +50,6 @@ class EnumConstraint extends Constraint
             }
         }
 
-        $this->addError($path, 'Does not have a value in the enumeration ' . json_encode($schema->enum), 'enum', array('enum' => $schema->enum));
+        $this->addError($path, ConstraintError::ENUM(), array('enum' => $schema->enum));
     }
 }

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Rfc3339;
 
@@ -33,49 +34,67 @@ class FormatConstraint extends Constraint
         switch ($schema->format) {
             case 'date':
                 if (!$date = $this->validateDateTime($element, 'Y-m-d')) {
-                    $this->addError($path, sprintf('Invalid date %s, expected format YYYY-MM-DD', json_encode($element)), 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_DATE(), array(
+                            'date' => $element,
+                            'format' => $schema->format
+                        )
+                    );
                 }
                 break;
 
             case 'time':
                 if (!$this->validateDateTime($element, 'H:i:s')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected format hh:mm:ss', json_encode($element)), 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_TIME(), array(
+                            'time' => json_encode($element),
+                            'format' => $schema->format,
+                        )
+                    );
                 }
                 break;
 
             case 'date-time':
                 if (null === Rfc3339::createFromString($element)) {
-                    $this->addError($path, sprintf('Invalid date-time %s, expected format YYYY-MM-DDThh:mm:ssZ or YYYY-MM-DDThh:mm:ss+hh:mm', json_encode($element)), 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_DATE_TIME(), array(
+                            'dateTime' => json_encode($element),
+                            'format' => $schema->format
+                        )
+                    );
                 }
                 break;
 
             case 'utc-millisec':
                 if (!$this->validateDateTime($element, 'U')) {
-                    $this->addError($path, sprintf('Invalid time %s, expected integer of milliseconds since Epoch', json_encode($element)), 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_DATE_UTC(), array(
+                        'value' => $element,
+                        'format' => $schema->format));
                 }
                 break;
 
             case 'regex':
                 if (!$this->validateRegex($element)) {
-                    $this->addError($path, 'Invalid regex format ' . $element, 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_REGEX(), array(
+                            'value' => $element,
+                            'format' => $schema->format
+                        )
+                    );
                 }
                 break;
 
             case 'color':
                 if (!$this->validateColor($element)) {
-                    $this->addError($path, 'Invalid color', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_COLOR(), array('format' => $schema->format));
                 }
                 break;
 
             case 'style':
                 if (!$this->validateStyle($element)) {
-                    $this->addError($path, 'Invalid style', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_STYLE(), array('format' => $schema->format));
                 }
                 break;
 
             case 'phone':
                 if (!$this->validatePhone($element)) {
-                    $this->addError($path, 'Invalid phone number', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_PHONE(), array('format' => $schema->format));
                 }
                 break;
 
@@ -99,34 +118,34 @@ class FormatConstraint extends Constraint
                         $validURL = null;
                     }
                     if ($validURL === null) {
-                        $this->addError($path, 'Invalid URL format', 'format', array('format' => $schema->format));
+                        $this->addError($path, ConstraintError::FORMAT_URL(), array('format' => $schema->format));
                     }
                 }
                 break;
 
             case 'email':
                 if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError($path, 'Invalid email', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_EMAIL(), array('format' => $schema->format));
                 }
                 break;
 
             case 'ip-address':
             case 'ipv4':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)) {
-                    $this->addError($path, 'Invalid IP address', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_IP(), array('format' => $schema->format));
                 }
                 break;
 
             case 'ipv6':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV6)) {
-                    $this->addError($path, 'Invalid IP address', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_IP(), array('format' => $schema->format));
                 }
                 break;
 
             case 'host-name':
             case 'hostname':
                 if (!$this->validateHostname($element)) {
-                    $this->addError($path, 'Invalid hostname', 'format', array('format' => $schema->format));
+                    $this->addError($path, ConstraintError::FORMAT_HOSTNAME(), array('format' => $schema->format));
                 }
                 break;
 

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -34,7 +34,7 @@ class FormatConstraint extends Constraint
         switch ($schema->format) {
             case 'date':
                 if (!$date = $this->validateDateTime($element, 'Y-m-d')) {
-                    $this->addError($path, ConstraintError::FORMAT_DATE(), array(
+                    $this->addError(ConstraintError::FORMAT_DATE(), $path, array(
                             'date' => $element,
                             'format' => $schema->format
                         )
@@ -44,7 +44,7 @@ class FormatConstraint extends Constraint
 
             case 'time':
                 if (!$this->validateDateTime($element, 'H:i:s')) {
-                    $this->addError($path, ConstraintError::FORMAT_TIME(), array(
+                    $this->addError(ConstraintError::FORMAT_TIME(), $path, array(
                             'time' => json_encode($element),
                             'format' => $schema->format,
                         )
@@ -54,7 +54,7 @@ class FormatConstraint extends Constraint
 
             case 'date-time':
                 if (null === Rfc3339::createFromString($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_DATE_TIME(), array(
+                    $this->addError(ConstraintError::FORMAT_DATE_TIME(), $path, array(
                             'dateTime' => json_encode($element),
                             'format' => $schema->format
                         )
@@ -64,7 +64,7 @@ class FormatConstraint extends Constraint
 
             case 'utc-millisec':
                 if (!$this->validateDateTime($element, 'U')) {
-                    $this->addError($path, ConstraintError::FORMAT_DATE_UTC(), array(
+                    $this->addError(ConstraintError::FORMAT_DATE_UTC(), $path, array(
                         'value' => $element,
                         'format' => $schema->format));
                 }
@@ -72,7 +72,7 @@ class FormatConstraint extends Constraint
 
             case 'regex':
                 if (!$this->validateRegex($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_REGEX(), array(
+                    $this->addError(ConstraintError::FORMAT_REGEX(), $path, array(
                             'value' => $element,
                             'format' => $schema->format
                         )
@@ -82,19 +82,19 @@ class FormatConstraint extends Constraint
 
             case 'color':
                 if (!$this->validateColor($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_COLOR(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_COLOR(), $path, array('format' => $schema->format));
                 }
                 break;
 
             case 'style':
                 if (!$this->validateStyle($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_STYLE(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_STYLE(), $path, array('format' => $schema->format));
                 }
                 break;
 
             case 'phone':
                 if (!$this->validatePhone($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_PHONE(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_PHONE(), $path, array('format' => $schema->format));
                 }
                 break;
 
@@ -118,34 +118,34 @@ class FormatConstraint extends Constraint
                         $validURL = null;
                     }
                     if ($validURL === null) {
-                        $this->addError($path, ConstraintError::FORMAT_URL(), array('format' => $schema->format));
+                        $this->addError(ConstraintError::FORMAT_URL(), $path, array('format' => $schema->format));
                     }
                 }
                 break;
 
             case 'email':
                 if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)) {
-                    $this->addError($path, ConstraintError::FORMAT_EMAIL(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_EMAIL(), $path, array('format' => $schema->format));
                 }
                 break;
 
             case 'ip-address':
             case 'ipv4':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV4)) {
-                    $this->addError($path, ConstraintError::FORMAT_IP(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_IP(), $path, array('format' => $schema->format));
                 }
                 break;
 
             case 'ipv6':
                 if (null === filter_var($element, FILTER_VALIDATE_IP, FILTER_NULL_ON_FAILURE | FILTER_FLAG_IPV6)) {
-                    $this->addError($path, ConstraintError::FORMAT_IP(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_IP(), $path, array('format' => $schema->format));
                 }
                 break;
 
             case 'host-name':
             case 'hostname':
                 if (!$this->validateHostname($element)) {
-                    $this->addError($path, ConstraintError::FORMAT_HOSTNAME(), array('format' => $schema->format));
+                    $this->addError(ConstraintError::FORMAT_HOSTNAME(), $path, array('format' => $schema->format));
                 }
                 break;
 

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -29,40 +29,40 @@ class NumberConstraint extends Constraint
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
-                    $this->addError($path, ConstraintError::EXCLUSIVE_MINIMUM(), array('minimum' => $schema->minimum));
+                    $this->addError(ConstraintError::EXCLUSIVE_MINIMUM(), $path, array('minimum' => $schema->minimum));
                 } elseif ($element < $schema->minimum) {
-                    $this->addError($path, ConstraintError::MINIMUM(), array('minimum' => $schema->minimum));
+                    $this->addError(ConstraintError::MINIMUM(), $path, array('minimum' => $schema->minimum));
                 }
             } else {
-                $this->addError($path, ConstraintError::MISSING_MINIMUM());
+                $this->addError(ConstraintError::MISSING_MINIMUM(), $path);
             }
         } elseif (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError($path, ConstraintError::MINIMUM(), array('minimum' => $schema->minimum));
+            $this->addError(ConstraintError::MINIMUM(), $path, array('minimum' => $schema->minimum));
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
-                    $this->addError($path, ConstraintError::EXCLUSIVE_MAXIMUM(), array('maximum' => $schema->maximum));
+                    $this->addError(ConstraintError::EXCLUSIVE_MAXIMUM(), $path, array('maximum' => $schema->maximum));
                 } elseif ($element > $schema->maximum) {
-                    $this->addError($path, ConstraintError::MAXIMUM(), array('maximum' => $schema->maximum));
+                    $this->addError(ConstraintError::MAXIMUM(), $path, array('maximum' => $schema->maximum));
                 }
             } else {
-                $this->addError($path, ConstraintError::MISSING_MAXIMUM());
+                $this->addError(ConstraintError::MISSING_MAXIMUM(), $path);
             }
         } elseif (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError($path, ConstraintError::MAXIMUM(), array('maximum' => $schema->maximum));
+            $this->addError(ConstraintError::MAXIMUM(), $path, array('maximum' => $schema->maximum));
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError($path, ConstraintError::DIVISIBLE_BY(), array('divisibleBy' => $schema->divisibleBy));
+            $this->addError(ConstraintError::DIVISIBLE_BY(), $path, array('divisibleBy' => $schema->divisibleBy));
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError($path, ConstraintError::MULTIPLE_OF(), array('multipleOf' => $schema->multipleOf));
+            $this->addError(ConstraintError::MULTIPLE_OF(), $path, array('multipleOf' => $schema->multipleOf));
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
 /**
@@ -28,40 +29,40 @@ class NumberConstraint extends Constraint
         if (isset($schema->exclusiveMinimum)) {
             if (isset($schema->minimum)) {
                 if ($schema->exclusiveMinimum && $element <= $schema->minimum) {
-                    $this->addError($path, 'Must have a minimum value of ' . $schema->minimum, 'exclusiveMinimum', array('minimum' => $schema->minimum));
+                    $this->addError($path, ConstraintError::EXCLUSIVE_MINIMUM(), array('minimum' => $schema->minimum));
                 } elseif ($element < $schema->minimum) {
-                    $this->addError($path, 'Must have a minimum value of ' . $schema->minimum, 'minimum', array('minimum' => $schema->minimum));
+                    $this->addError($path, ConstraintError::MINIMUM(), array('minimum' => $schema->minimum));
                 }
             } else {
-                $this->addError($path, 'Use of exclusiveMinimum requires presence of minimum', 'missingMinimum');
+                $this->addError($path, ConstraintError::MISSING_MINIMUM());
             }
         } elseif (isset($schema->minimum) && $element < $schema->minimum) {
-            $this->addError($path, 'Must have a minimum value of ' . $schema->minimum, 'minimum', array('minimum' => $schema->minimum));
+            $this->addError($path, ConstraintError::MINIMUM(), array('minimum' => $schema->minimum));
         }
 
         // Verify maximum
         if (isset($schema->exclusiveMaximum)) {
             if (isset($schema->maximum)) {
                 if ($schema->exclusiveMaximum && $element >= $schema->maximum) {
-                    $this->addError($path, 'Must have a maximum value of ' . $schema->maximum, 'exclusiveMaximum', array('maximum' => $schema->maximum));
+                    $this->addError($path, ConstraintError::EXCLUSIVE_MAXIMUM(), array('maximum' => $schema->maximum));
                 } elseif ($element > $schema->maximum) {
-                    $this->addError($path, 'Must have a maximum value of ' . $schema->maximum, 'maximum', array('maximum' => $schema->maximum));
+                    $this->addError($path, ConstraintError::MAXIMUM(), array('maximum' => $schema->maximum));
                 }
             } else {
-                $this->addError($path, 'Use of exclusiveMaximum requires presence of maximum', 'missingMaximum');
+                $this->addError($path, ConstraintError::MISSING_MAXIMUM());
             }
         } elseif (isset($schema->maximum) && $element > $schema->maximum) {
-            $this->addError($path, 'Must have a maximum value of ' . $schema->maximum, 'maximum', array('maximum' => $schema->maximum));
+            $this->addError($path, ConstraintError::MAXIMUM(), array('maximum' => $schema->maximum));
         }
 
         // Verify divisibleBy - Draft v3
         if (isset($schema->divisibleBy) && $this->fmod($element, $schema->divisibleBy) != 0) {
-            $this->addError($path, 'Is not divisible by ' . $schema->divisibleBy, 'divisibleBy', array('divisibleBy' => $schema->divisibleBy));
+            $this->addError($path, ConstraintError::DIVISIBLE_BY(), array('divisibleBy' => $schema->divisibleBy));
         }
 
         // Verify multipleOf - Draft v4
         if (isset($schema->multipleOf) && $this->fmod($element, $schema->multipleOf) != 0) {
-            $this->addError($path, 'Must be a multiple of ' . $schema->multipleOf, 'multipleOf', array('multipleOf' => $schema->multipleOf));
+            $this->addError($path, ConstraintError::MULTIPLE_OF(), array('multipleOf' => $schema->multipleOf));
         }
 
         $this->checkFormat($element, $schema, $path, $i);

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -58,7 +58,7 @@ class ObjectConstraint extends Constraint
 
             // Validate the pattern before using it to test for matches
             if (@preg_match($delimiter . $pregex . $delimiter . 'u', '') === false) {
-                $this->addError($path, ConstraintError::PREGEX_INVALID(), array('pregex' => $pregex));
+                $this->addError(ConstraintError::PREGEX_INVALID(), $path, array('pregex' => $pregex));
                 continue;
             }
             foreach ($element as $i => $value) {
@@ -90,7 +90,7 @@ class ObjectConstraint extends Constraint
 
             // no additional properties allowed
             if (!in_array($i, $matches) && $additionalProp === false && $this->inlineSchemaProperty !== $i && !$definition) {
-                $this->addError($path, ConstraintError::ADDITIONAL_PROPERTIES(), array('property' => $i));
+                $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, array('property' => $i));
             }
 
             // additional properties defined
@@ -105,7 +105,7 @@ class ObjectConstraint extends Constraint
             // property requires presence of another
             $require = $this->getProperty($definition, 'requires');
             if ($require && !$this->getProperty($element, $require)) {
-                $this->addError($path, ConstraintError::REQUIRES(), array(
+                $this->addError(ConstraintError::REQUIRES(), $path, array(
                     'property' => $i,
                     'requiredProperty' => $require
                 ));
@@ -172,13 +172,13 @@ class ObjectConstraint extends Constraint
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) < $objectDefinition->minProperties) {
-                $this->addError($path, ConstraintError::PROPERTIES_MIN(), array('minProperties' => $objectDefinition->minProperties));
+                $this->addError(ConstraintError::PROPERTIES_MIN(), $path, array('minProperties' => $objectDefinition->minProperties));
             }
         }
         // Verify maximum number of properties
         if (isset($objectDefinition->maxProperties) && !is_object($objectDefinition->maxProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) > $objectDefinition->maxProperties) {
-                $this->addError($path, ConstraintError::PROPERTIES_MAX(), array('maxProperties' => $objectDefinition->maxProperties));
+                $this->addError(ConstraintError::PROPERTIES_MAX(), $path, array('maxProperties' => $objectDefinition->maxProperties));
             }
         }
     }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 
 /**
@@ -26,21 +27,21 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError($path, 'Must be at most ' . $schema->maxLength . ' characters long', 'maxLength', array(
+            $this->addError($path, ConstraintError::LENGTH_MAX(), array(
                 'maxLength' => $schema->maxLength,
             ));
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError($path, 'Must be at least ' . $schema->minLength . ' characters long', 'minLength', array(
+            $this->addError($path, ConstraintError::LENGTH_MIN(), array(
                 'minLength' => $schema->minLength,
             ));
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#u', $element)) {
-            $this->addError($path, 'Does not match the regex pattern ' . $schema->pattern, 'pattern', array(
+            $this->addError($path, ConstraintError::PATTERN(), array(
                 'pattern' => $schema->pattern,
             ));
         }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -27,21 +27,21 @@ class StringConstraint extends Constraint
     {
         // Verify maxLength
         if (isset($schema->maxLength) && $this->strlen($element) > $schema->maxLength) {
-            $this->addError($path, ConstraintError::LENGTH_MAX(), array(
+            $this->addError(ConstraintError::LENGTH_MAX(), $path, array(
                 'maxLength' => $schema->maxLength,
             ));
         }
 
         //verify minLength
         if (isset($schema->minLength) && $this->strlen($element) < $schema->minLength) {
-            $this->addError($path, ConstraintError::LENGTH_MIN(), array(
+            $this->addError(ConstraintError::LENGTH_MIN(), $path, array(
                 'minLength' => $schema->minLength,
             ));
         }
 
         // Verify a regex pattern
         if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#u', $element)) {
-            $this->addError($path, ConstraintError::PATTERN(), array(
+            $this->addError(ConstraintError::PATTERN(), $path, array(
                 'pattern' => $schema->pattern,
             ));
         }

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -9,6 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
+use JsonSchema\ConstraintError;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\InvalidArgumentException;
 use UnexpectedValueException as StandardUnexpectedValueException;
@@ -60,8 +61,10 @@ class TypeConstraint extends Constraint
                 $this->validateTypeNameWording($type);
                 $wording[] = self::$wording[$type];
             }
-            $this->addError($path, ucwords(gettype($value)) . ' value found, but ' .
-                $this->implodeWith($wording, ', ', 'or') . ' is required', 'type');
+            $this->addError($path, ConstraintError::TYPE(), array(
+                    'expected' => gettype($value),
+                    'found' => $this->implodeWith($wording, ', ', 'or')
+            ));
         }
     }
 

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -61,7 +61,7 @@ class TypeConstraint extends Constraint
                 $this->validateTypeNameWording($type);
                 $wording[] = self::$wording[$type];
             }
-            $this->addError($path, ConstraintError::TYPE(), array(
+            $this->addError(ConstraintError::TYPE(), $path, array(
                     'expected' => gettype($value),
                     'found' => $this->implodeWith($wording, ', ', 'or')
             ));

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -161,7 +161,8 @@ class UndefinedConstraint extends Constraint
                 foreach ($schema->required as $required) {
                     if (!$this->getTypeCheck()->propertyExists($value, $required)) {
                         $this->addError(
-                            $this->incrementPath($path ?: new JsonPointer(''), $required), ConstraintError::REQUIRED(), array(
+                            ConstraintError::REQUIRED(),
+                            $this->incrementPath($path ?: new JsonPointer(''), $required), array(
                                 'property' => $required
                             )
                         );
@@ -170,7 +171,7 @@ class UndefinedConstraint extends Constraint
             } elseif (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ($schema->required && $value instanceof self) {
-                    $this->addError($path, ConstraintError::REQUIRED_D3());
+                    $this->addError(ConstraintError::REQUIRED_D3(), $path);
                 }
             }
         }
@@ -190,7 +191,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised it must be a disallowed value
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, ConstraintError::DISALLOW());
+                $this->addError(ConstraintError::DISALLOW(), $path);
             } else {
                 $this->errors = $initErrors;
             }
@@ -202,7 +203,7 @@ class UndefinedConstraint extends Constraint
 
             // if no new errors were raised then the instance validated against the "not" schema
             if (count($this->getErrors()) == count($initErrors)) {
-                $this->addError($path, ConstraintError::NOT());
+                $this->addError(ConstraintError::NOT(), $path);
             } else {
                 $this->errors = $initErrors;
             }
@@ -237,7 +238,7 @@ class UndefinedConstraint extends Constraint
                 $isValid = $isValid && (count($this->getErrors()) == count($initErrors));
             }
             if (!$isValid) {
-                $this->addError($path, ConstraintError::ALL_OF());
+                $this->addError(ConstraintError::ALL_OF(), $path);
             }
         }
 
@@ -252,7 +253,7 @@ class UndefinedConstraint extends Constraint
                 }
             }
             if (!$isValid) {
-                $this->addError($path, ConstraintError::ANY_OF());
+                $this->addError(ConstraintError::ANY_OF(), $path);
             } else {
                 $this->errors = $startErrors;
             }
@@ -272,7 +273,7 @@ class UndefinedConstraint extends Constraint
             }
             if ($matchedSchemas !== 1) {
                 $this->addErrors(array_merge($allErrors, $startErrors));
-                $this->addError($path, ConstraintError::ONE_OF());
+                $this->addError(ConstraintError::ONE_OF(), $path);
             } else {
                 $this->errors = $startErrors;
             }
@@ -294,7 +295,7 @@ class UndefinedConstraint extends Constraint
                 if (is_string($dependency)) {
                     // Draft 3 string is allowed - e.g. "dependencies": {"bar": "foo"}
                     if (!$this->getTypeCheck()->propertyExists($value, $dependency)) {
-                        $this->addError($path, ConstraintError::DEPENDENCIES(), array(
+                        $this->addError(ConstraintError::DEPENDENCIES(), $path, array(
                             'key' => $key,
                             'dependency' => $dependency
                         ));
@@ -303,7 +304,7 @@ class UndefinedConstraint extends Constraint
                     // Draft 4 must be an array - e.g. "dependencies": {"bar": ["foo"]}
                     foreach ($dependency as $d) {
                         if (!$this->getTypeCheck()->propertyExists($value, $d)) {
-                            $this->addError($path, ConstraintError::DEPENDENCIES(), array(
+                            $this->addError(ConstraintError::DEPENDENCIES(), $path, array(
                                 'key' => $key,
                                 'dependency' => $dependency
                             ));

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -36,7 +36,12 @@ class AdditionalPropertiesTest extends BaseTestCase
                         'property'   => '',
                         'pointer'    => '',
                         'message'    => 'The property additionalProp is not defined and the definition does not allow additional properties',
-                        'constraint' => 'additionalProp',
+                        'constraint' => array(
+                            'name' => 'additionalProp',
+                            'params' => array(
+                                'property' => 'additionalProp'
+                            )
+                        )
                     )
                 )
             ),

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -76,12 +76,16 @@ class OfPropertiesTest extends BaseTestCase
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a string is required',
                         'constraint' => 'type',
+                        'expected'   => 'array',
+                        'found'      => 'a string'
                     ),
                     array(
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a number is required',
                         'constraint' => 'type',
+                        'expected'   => 'array',
+                        'found'      => 'a number'
                     ),
                     array(
                         'property'   => 'prop2',

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -75,23 +75,34 @@ class OfPropertiesTest extends BaseTestCase
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a string is required',
-                        'constraint' => 'type',
-                        'expected'   => 'array',
-                        'found'      => 'a string'
+                        'constraint' => array(
+                            'name' => 'type',
+                            'params' => array(
+                                'expected'   => 'array',
+                                'found'      => 'a string'
+                            )
+                        )
                     ),
                     array(
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Array value found, but a number is required',
-                        'constraint' => 'type',
-                        'expected'   => 'array',
-                        'found'      => 'a number'
+                        'constraint' => array(
+                            'name' => 'type',
+                            'params' => array(
+                                'expected'   => 'array',
+                                'found'      => 'a number'
+                            )
+                        )
                     ),
                     array(
                         'property'   => 'prop2',
                         'pointer'    => '/prop2',
                         'message'    => 'Failed to match exactly one schema',
-                        'constraint' => 'oneOf',
+                        'constraint' => array(
+                            'name' => 'oneOf',
+                            'params' => array()
+                        )
                     ),
                 ),
             ),

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -88,25 +88,45 @@ class PointerTest extends \PHPUnit_Framework_TestCase
                     'property' => 'prop1',
                     'pointer' => '/prop1',
                     'message' => 'The property prop1 is required',
-                    'constraint' => 'required'
+                    'constraint' => array(
+                        'name' => 'required',
+                        'params' => array(
+                            'property' => 'prop1'
+                        )
+                    )
                 ),
                 array(
                     'property' => 'prop2.prop2.1',
                     'pointer' => '/prop2/prop2.1',
                     'message' => 'The property prop2.1 is required',
-                    'constraint' => 'required'
+                    'constraint' => array(
+                        'name' => 'required',
+                        'params' => array(
+                            'property' => 'prop2.1'
+                        )
+                    )
                 ),
                 array(
                     'property' => 'prop3.prop3/1.prop3/1.1',
                     'pointer' => '/prop3/prop3~11/prop3~11.1',
                     'message' => 'The property prop3/1.1 is required',
-                    'constraint' => 'required'
+                    'constraint' => array(
+                        'name' => 'required',
+                        'params' => array(
+                            'property' => 'prop3/1.1'
+                        )
+                    )
                 ),
                 array(
                     'property' => 'prop4[0].prop4-child',
                     'pointer' => '/prop4/0/prop4-child',
                     'message' => 'The property prop4-child is required',
-                    'constraint' => 'required'
+                    'constraint' => array(
+                        'name' => 'required',
+                        'params' => array(
+                            'property' => 'prop4-child'
+                        )
+                    )
                 )
             ),
             $validator->getErrors()


### PR DESCRIPTION
Some improvements to the error system in an effort to make things a little easier for people interested in adding localization, such as https://github.com/justinrainbow/json-schema/issues/363:

* Added a new class: `ConstraintError`. This extends an `enum` class which I've brought into the project to ensure that nobody types constraint types or messages directly into the code (by typehinting `addError`). I've used it before in a number of projects and have found it quite useful. 

* Converted all error strings into a format that can be passed to `sprintf`.

* I had to invent a few new format error types to avoid ambiguity: `phoneFormat`, `ipFormat`, `styleFormat`, `timeFormat`, `urlFormat`. 

@bighappyface @erayd @harej