### PR TITLE
Fix infinite recursion on some schemas when setting defaults (#359)

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,7 @@ third argument to `Validator::validate()`, or can be provided as the third argum
 | `Constraint::CHECK_MODE_TYPE_CAST` | Enable fuzzy type checking for associative arrays and objects |
 | `Constraint::CHECK_MODE_COERCE_TYPES` | Convert data types to match the schema where possible |
 | `Constraint::CHECK_MODE_APPLY_DEFAULTS` | Apply default values from the schema if not set |
+| `Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS` | When applying defaults, only set values that are required |
 | `Constraint::CHECK_MODE_EXCEPTIONS` | Throw an exception immediately if validation fails |
 | `Constraint::CHECK_MODE_DISABLE_FORMAT` | Do not validate "format" constraints |
 

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -31,6 +31,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     const CHECK_MODE_APPLY_DEFAULTS =   0x00000008;
     const CHECK_MODE_EXCEPTIONS =       0x00000010;
     const CHECK_MODE_DISABLE_FORMAT =   0x00000020;
+    const CHECK_MODE_ONLY_REQUIRED_DEFAULTS   = 0x00000080;
 
     /**
      * Bubble down the path

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -79,10 +79,10 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param mixed            $i
      * @param mixed            $patternProperties
      */
-    protected function checkObject(&$value, $schema = null, JsonPointer $path = null, $i = null, $patternProperties = null)
+    protected function checkObject(&$value, $schema = null, JsonPointer $path = null, $i = null, $patternProperties = null, $appliedDefaults = array())
     {
         $validator = $this->factory->createInstanceFor('object');
-        $validator->check($value, $schema, $path, $i, $patternProperties);
+        $validator->check($value, $schema, $path, $i, $patternProperties, $appliedDefaults);
 
         $this->addErrors($validator->getErrors());
     }
@@ -111,11 +111,11 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
      * @param JsonPointer|null $path
      * @param mixed            $i
      */
-    protected function checkUndefined(&$value, $schema = null, JsonPointer $path = null, $i = null)
+    protected function checkUndefined(&$value, $schema = null, JsonPointer $path = null, $i = null, $fromDefault = false)
     {
         $validator = $this->factory->createInstanceFor('undefined');
 
-        $validator->check($value, $this->factory->getSchemaStorage()->resolveRefSchema($schema), $path, $i);
+        $validator->check($value, $this->factory->getSchemaStorage()->resolveRefSchema($schema), $path, $i, $fromDefault);
 
         $this->addErrors($validator->getErrors());
     }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -21,13 +21,20 @@ use JsonSchema\Entity\JsonPointer;
 class ObjectConstraint extends Constraint
 {
     /**
+     * @var array List of properties to which a default value has been applied
+     */
+    protected $appliedDefaults = array();
+
+    /**
      * {@inheritdoc}
      */
-    public function check(&$element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null)
+    public function check(&$element, $definition = null, JsonPointer $path = null, $additionalProp = null, $patternProperties = null, $appliedDefaults = array())
     {
         if ($element instanceof UndefinedConstraint) {
             return;
         }
+
+        $this->appliedDefaults = $appliedDefaults;
 
         $matches = array();
         if ($patternProperties) {
@@ -64,7 +71,7 @@ class ObjectConstraint extends Constraint
             foreach ($element as $i => $value) {
                 if (preg_match($delimiter . $pregex . $delimiter . 'u', $i)) {
                     $matches[] = $i;
-                    $this->checkUndefined($value, $schema ?: new \stdClass(), $path, $i);
+                    $this->checkUndefined($value, $schema ?: new \stdClass(), $path, $i, in_array($i, $this->appliedDefaults));
                 }
             }
         }
@@ -96,9 +103,9 @@ class ObjectConstraint extends Constraint
             // additional properties defined
             if (!in_array($i, $matches) && $additionalProp && !$definition) {
                 if ($additionalProp === true) {
-                    $this->checkUndefined($value, null, $path, $i);
+                    $this->checkUndefined($value, null, $path, $i, in_array($i, $this->appliedDefaults));
                 } else {
-                    $this->checkUndefined($value, $additionalProp, $path, $i);
+                    $this->checkUndefined($value, $additionalProp, $path, $i, in_array($i, $this->appliedDefaults));
                 }
             }
 
@@ -135,7 +142,7 @@ class ObjectConstraint extends Constraint
 
             if (is_object($definition)) {
                 // Undefined constraint will check for is_object() and quit if is not - so why pass it?
-                $this->checkUndefined($property, $definition, $path, $i);
+                $this->checkUndefined($property, $definition, $path, $i, in_array($i, $this->appliedDefaults));
             }
         }
     }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -114,6 +114,7 @@ class UndefinedConstraint extends Constraint
         // Apply default values from schema
         if ($this->factory->getConfig(self::CHECK_MODE_APPLY_DEFAULTS)) {
             if (isset($schema->properties) && LooseTypeCheck::isObject($value)) {
+                // $value is an object or assoc array, and properties are defined - treat as an object
                 foreach ($schema->properties as $currentProperty => $propertyDefinition) {
                     if (!LooseTypeCheck::propertyExists($value, $currentProperty) && isset($propertyDefinition->default)) {
                         if (is_object($propertyDefinition->default)) {
@@ -124,7 +125,7 @@ class UndefinedConstraint extends Constraint
                     }
                 }
             } elseif (isset($schema->items) && LooseTypeCheck::isArray($value)) {
-                // $value is an array, and default items are defined - treat as plain array
+                // $value is an array, and items are defined - treat as plain array
                 foreach ($schema->items as $currentProperty => $itemDefinition) {
                     if (!isset($value[$currentProperty]) && isset($itemDefinition->default)) {
                         if (is_object($itemDefinition->default)) {

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -113,38 +113,24 @@ class UndefinedConstraint extends Constraint
 
         // Apply default values from schema
         if ($this->factory->getConfig(self::CHECK_MODE_APPLY_DEFAULTS)) {
-            if ($this->getTypeCheck()->isObject($value) && isset($schema->properties)) {
-                // $value is an object, so apply default properties if defined
+            if (isset($schema->properties) && LooseTypeCheck::isObject($value)) {
                 foreach ($schema->properties as $currentProperty => $propertyDefinition) {
-                    if (!$this->getTypeCheck()->propertyExists($value, $currentProperty) && isset($propertyDefinition->default)) {
+                    if (!LooseTypeCheck::propertyExists($value, $currentProperty) && isset($propertyDefinition->default)) {
                         if (is_object($propertyDefinition->default)) {
-                            $this->getTypeCheck()->propertySet($value, $currentProperty, clone $propertyDefinition->default);
+                            LooseTypeCheck::propertySet($value, $currentProperty, clone $propertyDefinition->default);
                         } else {
-                            $this->getTypeCheck()->propertySet($value, $currentProperty, $propertyDefinition->default);
+                            LooseTypeCheck::propertySet($value, $currentProperty, $propertyDefinition->default);
                         }
                     }
                 }
-            } elseif ($this->getTypeCheck()->isArray($value)) {
-                if (isset($schema->properties)) {
-                    // $value is an array, but default properties are defined, so treat as assoc
-                    foreach ($schema->properties as $currentProperty => $propertyDefinition) {
-                        if (!isset($value[$currentProperty]) && isset($propertyDefinition->default)) {
-                            if (is_object($propertyDefinition->default)) {
-                                $value[$currentProperty] = clone $propertyDefinition->default;
-                            } else {
-                                $value[$currentProperty] = $propertyDefinition->default;
-                            }
-                        }
-                    }
-                } elseif (isset($schema->items)) {
-                    // $value is an array, and default items are defined - treat as plain array
-                    foreach ($schema->items as $currentProperty => $itemDefinition) {
-                        if (!isset($value[$currentProperty]) && isset($itemDefinition->default)) {
-                            if (is_object($itemDefinition->default)) {
-                                $value[$currentProperty] = clone $itemDefinition->default;
-                            } else {
-                                $value[$currentProperty] = $itemDefinition->default;
-                            }
+            } elseif (isset($schema->items) && LooseTypeCheck::isArray($value)) {
+                // $value is an array, and default items are defined - treat as plain array
+                foreach ($schema->items as $currentProperty => $itemDefinition) {
+                    if (!isset($value[$currentProperty]) && isset($itemDefinition->default)) {
+                        if (is_object($itemDefinition->default)) {
+                            $value[$currentProperty] = clone $itemDefinition->default;
+                        } else {
+                            $value[$currentProperty] = $itemDefinition->default;
                         }
                     }
                 }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -122,7 +122,7 @@ class UndefinedConstraint extends Constraint
 
         // Apply default values from schema
         if (!$path->fromDefault()) {
-            $this->applyDefaultValues($value, $schema);
+            $this->applyDefaultValues($value, $schema, $path);
         }
 
         // Verify required values
@@ -189,10 +189,11 @@ class UndefinedConstraint extends Constraint
     /**
      * Apply default values
      *
-     * @param mixed $value
-     * @param mixed $schema
+     * @param mixed       $value
+     * @param mixed       $schema
+     * @param JsonPointer $path
      */
-    protected function applyDefaultValues(&$value, $schema)
+    protected function applyDefaultValues(&$value, $schema, $path)
     {
         // only apply defaults if feature is enabled
         if (!$this->factory->getConfig(self::CHECK_MODE_APPLY_DEFAULTS)) {
@@ -251,10 +252,12 @@ class UndefinedConstraint extends Constraint
                         $value[$currentItem] = $itemDefinition->default;
                     }
                 }
+                $path->setFromDefault();
             }
         } elseif (($value instanceof self || $value === null) && isset($schema->default) && $shouldApply($schema)) {
             // $value is a leaf, not a container - apply the default directly
             $value = is_object($schema->default) ? clone $schema->default : $schema->default;
+            $path->setFromDefault();
         }
     }
 

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -189,9 +189,10 @@ class UndefinedConstraint extends Constraint
         }
 
         // check whether this default should be applied
-        $shouldApply = function ($definition, $name = null) use ($schema) {
+        $requiredOnly = $this->factory->getConfig(self::CHECK_MODE_ONLY_REQUIRED_DEFAULTS);
+        $shouldApply = function ($definition, $name = null) use ($schema, $requiredOnly) {
             // required-only mode is off
-            if (!$this->factory->getConfig(self::CHECK_MODE_ONLY_REQUIRED_DEFAULTS)) {
+            if (!$requiredOnly) {
                 return true;
             }
             // draft-04 required is set

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -126,12 +126,12 @@ class UndefinedConstraint extends Constraint
                 }
             } elseif (isset($schema->items) && LooseTypeCheck::isArray($value)) {
                 // $value is an array, and items are defined - treat as plain array
-                foreach ($schema->items as $currentProperty => $itemDefinition) {
-                    if (!isset($value[$currentProperty]) && isset($itemDefinition->default)) {
+                foreach ($schema->items as $currentItem => $itemDefinition) {
+                    if (!isset($value[$currentItem]) && isset($itemDefinition->default)) {
                         if (is_object($itemDefinition->default)) {
-                            $value[$currentProperty] = clone $itemDefinition->default;
+                            $value[$currentItem] = clone $itemDefinition->default;
                         } else {
-                            $value[$currentProperty] = $itemDefinition->default;
+                            $value[$currentItem] = $itemDefinition->default;
                         }
                     }
                 }

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -204,7 +204,6 @@ class UndefinedConstraint extends Constraint
         // draft-04 required is set
         if (
             $name !== null
-            && is_object($parentSchema)
             && isset($parentSchema->required)
             && is_array($parentSchema->required)
             && in_array($name, $parentSchema->required)

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -239,7 +239,7 @@ class UndefinedConstraint extends Constraint
             foreach ($schema->properties as $currentProperty => $propertyDefinition) {
                 if (
                     !LooseTypeCheck::propertyExists($value, $currentProperty)
-                    && isset($propertyDefinition->default)
+                    && property_exists($propertyDefinition, 'default')
                     && $this->shouldApplyDefaultValue($requiredOnly, $propertyDefinition, $currentProperty, $schema)
                 ) {
                     // assign default value
@@ -255,8 +255,8 @@ class UndefinedConstraint extends Constraint
             // $value is an array, and items are defined - treat as plain array
             foreach ($schema->items as $currentItem => $itemDefinition) {
                 if (
-                    !isset($value[$currentItem])
-                    && isset($itemDefinition->default)
+                    !array_key_exists($currentItem, $value)
+                    && property_exists($itemDefinition, 'default')
                     && $this->shouldApplyDefaultValue($requiredOnly, $itemDefinition)) {
                     if (is_object($itemDefinition->default)) {
                         $value[$currentItem] = clone $itemDefinition->default;
@@ -267,8 +267,8 @@ class UndefinedConstraint extends Constraint
                 $path->setFromDefault();
             }
         } elseif (
-            ($value instanceof self || $value === null)
-            && isset($schema->default)
+            $value instanceof self
+            && property_exists($schema, 'default')
             && $this->shouldApplyDefaultValue($requiredOnly, $schema)) {
             // $value is a leaf, not a container - apply the default directly
             $value = is_object($schema->default) ? clone $schema->default : $schema->default;

--- a/src/JsonSchema/Entity/JsonPointer.php
+++ b/src/JsonSchema/Entity/JsonPointer.php
@@ -25,6 +25,11 @@ class JsonPointer
     private $propertyPaths = array();
 
     /**
+     * @var bool Whether the value at this path was set from a schema default
+     */
+    private $fromDefault = false;
+
+    /**
      * @param string $value
      *
      * @throws InvalidArgumentException when $value is not a string
@@ -134,5 +139,23 @@ class JsonPointer
     public function __toString()
     {
         return $this->getFilename() . $this->getPropertyPathAsString();
+    }
+
+    /**
+     * Mark the value at this path as being set from a schema default
+     */
+    public function setFromDefault()
+    {
+        $this->fromDefault = true;
+    }
+
+    /**
+     * Check whether the value at this path was set from a schema default
+     *
+     * @return bool
+     */
+    public function fromDefault()
+    {
+        return $this->fromDefault;
     }
 }

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -79,8 +79,18 @@ class SchemaStorage implements SchemaStorageInterface
     public function resolveRef($ref)
     {
         $jsonPointer = new JsonPointer($ref);
-        $refSchema = $this->getSchema($jsonPointer->getFilename());
 
+        // resolve filename for pointer
+        $fileName = $jsonPointer->getFilename();
+        if (!strlen($fileName)) {
+            throw new UnresolvableJsonPointerException(sprintf(
+                "Could not resolve fragment '%s': no file is defined",
+                $jsonPointer->getPropertyPathAsString()
+            ));
+        }
+
+        // get & process the schema
+        $refSchema = $this->getSchema($fileName);
         foreach ($jsonPointer->getPropertyPaths() as $path) {
             if (is_object($refSchema) && property_exists($refSchema, $path)) {
                 $refSchema = $this->resolveRefSchema($refSchema->{$path});

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -114,15 +114,13 @@ class DefaultPropertiesTest extends VeryBaseTestCase
             ),
             array(// #16 infinite recursion via $ref
                 '{}',
-                '{
-                    "properties": {
-                        "propertyOne": {
-                            "$ref": "#",
-                            "default": {}
-                        }
-                    }
-                }',
+                '{"properties":{"propertyOne": {"$ref": "#","default": {}}}}',
                 '{"propertyOne":{}}'
+            ),
+            array(// #17 default value for null
+                'null',
+                '{"default":"valueOne"}',
+                '"valueOne"'
             )
         );
     }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -19,77 +19,84 @@ class DefaultPropertiesTest extends VeryBaseTestCase
     public function getValidTests()
     {
         return array(
+            /*
+            // This test case was intended to check whether a default value can be applied for the
+            // entire object, however testing this case is impossible, because there is no way to
+            // distinguish between a deliberate top-level NULL and a top level that contains nothing.
+            // As such, the assumption is that a top-level NULL is deliberate, and should not be
+            // altered by replacing it with a default value.
             array(// #0 default value for entire object
                 '',
                 '{"default":"valueOne"}',
                 '"valueOne"'
             ),
-            array(// #1 default value in an empty object
+            */
+            array(// #0 default value in an empty object
                 '{}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":"valueOne"}'
             ),
-            array(// #2 default value for top-level property
+            array(// #1 default value for top-level property
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
-            array(// #3 default value for sub-property
+            array(// #2 default value for sub-property
                 '{"propertyOne":{}}',
                 '{"properties":{"propertyOne":{"properties":{"propertyTwo":{"default":"valueTwo"}}}}}',
                 '{"propertyOne":{"propertyTwo":"valueTwo"}}'
             ),
-            array(// #4 default value for sub-property with sibling
+            array(// #3 default value for sub-property with sibling
                 '{"propertyOne":{"propertyTwo":"valueTwo"}}',
                 '{"properties":{"propertyOne":{"properties":{"propertyThree":{"default":"valueThree"}}}}}',
                 '{"propertyOne":{"propertyTwo":"valueTwo","propertyThree":"valueThree"}}'
             ),
-            array(// #5 default value for top-level property with type check
+            array(// #4 default value for top-level property with type check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo","type":"string"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
-            array(// #6 default value for top-level property with v3 required check
+            array(// #5 default value for top-level property with v3 required check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo","required":"true"}}}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
-            array(// #7 default value for top-level property with v4 required check
+            array(// #6 default value for top-level property with v4 required check
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":"valueTwo"}},"required":["propertyTwo"]}',
                 '{"propertyOne":"valueOne","propertyTwo":"valueTwo"}'
             ),
-            array(// #8 default value for an already set property
+            array(// #7 default value for an already set property
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"default":"valueOne"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
             ),
-            array(// #9 default item value for an array
+            array(// #8 default item value for an array
                 '["valueOne"]',
                 '{"type":"array","items":[{},{"type":"string","default":"valueTwo"}]}',
                 '["valueOne","valueTwo"]'
             ),
-            array(// #10 default item value for an empty array
+            array(// #9 default item value for an empty array
                 '[]',
                 '{"type":"array","items":[{"type":"string","default":"valueOne"}]}',
                 '["valueOne"]'
             ),
-            array(// #11 property without a default available
+            array(// #10 property without a default available
                 '{"propertyOne":"alreadySetValueOne"}',
                 '{"properties":{"propertyOne":{"type":"string"}}}',
                 '{"propertyOne":"alreadySetValueOne"}'
             ),
-            array(// #12 default property value is an object
+            array(// #11 default property value is an object
                 '{"propertyOne":"valueOne"}',
                 '{"properties":{"propertyTwo":{"default":{}}}}',
                 '{"propertyOne":"valueOne","propertyTwo":{}}'
             ),
-            array(// #13 default item value is an object
+            array(// #12 default item value is an object
                 '[]',
                 '{"type":"array","items":[{"default":{}}]}',
                 '[{}]'
             ),
-            array(// #14 only set required values (draft-04)
+            array(// #13 only set required values (draft-04)
                 '{}',
                 '{
                     "properties": {
@@ -101,7 +108,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"propertyTwo":"valueTwo"}',
                 Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS
             ),
-            array(// #15 only set required values (draft-03)
+            array(// #14 only set required values (draft-03)
                 '{}',
                 '{
                     "properties": {
@@ -112,21 +119,36 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"propertyTwo":"valueTwo"}',
                 Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS
             ),
-            array(// #16 infinite recursion via $ref (object)
+            array(// #15 infinite recursion via $ref (object)
                 '{}',
                 '{"properties":{"propertyOne": {"$ref": "#","default": {}}}}',
                 '{"propertyOne":{}}'
             ),
-            array(// #17 infinite recursion via $ref (array)
+            array(// #16 infinite recursion via $ref (array)
                 '[]',
                 '{"items":[{"$ref":"#","default":[]}]}',
                 '[[]]'
             ),
-            array(// #18 default value for null
+            array(// #17 default top value does not overwrite defined null
                 'null',
                 '{"default":"valueOne"}',
-                '"valueOne"'
-            )
+                'null'
+            ),
+            array(// #18 default property value does not overwrite defined null
+                '{"propertyOne":null}',
+                '{"properties":{"propertyOne":{"default":"valueOne"}}}',
+                '{"propertyOne":null}'
+            ),
+            array(// #19 default value in an object is null
+                '{}',
+                '{"properties":{"propertyOne":{"default":null}}}',
+                '{"propertyOne":null}'
+            ),
+            array(// #20 default value in an array is null
+                '[]',
+                '{"items":[{"default":null}]}',
+                '[null]'
+            ),
         );
     }
 
@@ -180,8 +202,8 @@ class DefaultPropertiesTest extends VeryBaseTestCase
 
     public function testNoModificationViaReferences()
     {
-        $input = json_decode('');
-        $schema = json_decode('{"default":{"propertyOne":"valueOne"}}');
+        $input = json_decode('{}');
+        $schema = json_decode('{"properties":{"propertyOne":{"default":"valueOne"}}}');
 
         $validator = new Validator();
         $validator->validate($input, $schema, Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_APPLY_DEFAULTS);
@@ -189,7 +211,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $this->assertEquals('{"propertyOne":"valueOne"}', json_encode($input));
 
         $input->propertyOne = 'valueTwo';
-        $this->assertEquals('valueOne', $schema->default->propertyOne);
+        $this->assertEquals('valueOne', $schema->properties->propertyOne->default);
     }
 
     public function testLeaveBasicTypesAlone()

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -200,6 +200,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $this->assertEquals('"ThisIsAString"', json_encode($input));
 
         $schema = json_decode('{"items":[{"type":"string","default":"valueOne"}]}');
+        $validator->validate($input, $schema, Constraint::CHECK_MODE_APPLY_DEFAULTS);
         $this->assertEquals('"ThisIsAString"', json_encode($input));
     }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -150,4 +150,15 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $input->propertyOne = 'valueTwo';
         $this->assertEquals('valueOne', $schema->default->propertyOne);
     }
+
+    public function testLeaveBasicTypesAlone()
+    {
+        $input = json_decode('"ThisIsAString"');
+        $schema = json_decode('{"properties": {"propertyOne": {"default": "valueOne"}}}');
+
+        $validator = new Validator();
+        $validator->validate($input, $schema, Constraint::CHECK_MODE_APPLY_DEFAULTS);
+
+        $this->assertEquals('"ThisIsAString"', json_encode($input));
+    }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -160,5 +160,8 @@ class DefaultPropertiesTest extends VeryBaseTestCase
         $validator->validate($input, $schema, Constraint::CHECK_MODE_APPLY_DEFAULTS);
 
         $this->assertEquals('"ThisIsAString"', json_encode($input));
+
+        $schema = json_decode('{"items":[{"type":"string","default":"valueOne"}]}');
+        $this->assertEquals('"ThisIsAString"', json_encode($input));
     }
 }

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -112,12 +112,17 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"propertyTwo":"valueTwo"}',
                 Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS
             ),
-            array(// #16 infinite recursion via $ref
+            array(// #16 infinite recursion via $ref (object)
                 '{}',
                 '{"properties":{"propertyOne": {"$ref": "#","default": {}}}}',
                 '{"propertyOne":{}}'
             ),
-            array(// #17 default value for null
+            array(// #17 infinite recursion via $ref (array)
+                '[]',
+                '{"items":[{"$ref":"#","default":[]}]}',
+                '[[]]'
+            ),
+            array(// #18 default value for null
                 'null',
                 '{"default":"valueOne"}',
                 '"valueOne"'

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -119,6 +119,17 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
         $schemaStorage->resolveRef("$mainSchemaPath#/definitions/car");
     }
 
+    public function testResolveRefWithNoAssociatedFileName()
+    {
+        $this->setExpectedException(
+            'JsonSchema\Exception\UnresolvableJsonPointerException',
+            "Could not resolve fragment '#': no file is defined"
+        );
+
+        $schemaStorage = new SchemaStorage();
+        $schemaStorage->resolveRef('#');
+    }
+
     /**
      * @return object
      */


### PR DESCRIPTION
Made this PR to collaborate with @mathroc on #359. The root cause has been located and is not a bug, but the recursion needs to be mitigated, as infinite recursion of a validator is in violation of the spec.

Will backport the fix to 5.2.0 once this PR is merged.

## Changes Relating to #359
 * Add `CHECK_MODE_ONLY_REQUIRED_DEFAULTS`
 * Don't expand nested defaults (fixes #359)

## Other Changes
Seeing as I'm doing this defaults-related PR anyway, I figured I might as well do a little tidying-up of the defaults code, plus fix any other bugs I run into while tracking this one down.

 * Fix another bug with trying to fetch an empty URI
 * Refactor defaults to use `LooseTypeCheck` where appropriate
 * Move default-setting into its own method
 * Rename one of the defaults variables for clarity
 * Add tests:
    + Ensure non-container values aren't treated like containers;
    + Infinite recursion of default objects via `$ref`
    + Default values do not override defined `null`
    + Default values of `null` are correctly applied
 * Fix second test case for `DefaultPropertiesTest::testLeaveBasicTypesAlone`
 * Fix applying default values of `null` / not overwriting `null` (fixes #377)