### PR TITLE
Revert "An email is a string, not much else."

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -206,10 +206,6 @@ class TypeConstraint extends Constraint
             return is_string($value);
         }
 
-        if ('email' === $type) {
-            return is_string($value);
-        }
-
         if ('null' === $type) {
             return is_null($value);
         }


### PR DESCRIPTION
This reverts commit 73ef463f5ee1d50db9f01069c5a060a3d354888a.

'email' is only a valid type attribute in draft-03 (later versions of
the spec explicitly limit the value of type to the core primitive
types), and this code doesn't validate email addresses anyway. IMO we
should be validating it properly or not at all, and noting this went
away after draft-03 my opinion is on the not-at-all side of the fence.

Note that 'email' is *never* defined as a spec type, in any version -
it just slips in under the radar of the draft-03 language which allows
users to put arbitrary things in the type field.