### PR TITLE
add enum wrapper

### DIFF
--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -4,7 +4,7 @@ namespace JsonSchema;
 
 use JsonSchema\Exception\InvalidArgumentException;
 
-class ConstraintError extends \MabeEnum\Enum
+class ConstraintError extends Enum
 {
     const ADDITIONAL_ITEMS = 'additionalItems';
     const ADDITIONAL_PROPERTIES = 'additionalProp';

--- a/src/JsonSchema/Enum.php
+++ b/src/JsonSchema/Enum.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace JsonSchema;
+
+abstract class Enum extends \MabeEnum\Enum
+{
+}


### PR DESCRIPTION
Adding an intermediate `Enum` class. This way consumers of the library can extend `ConstraintError` without having references to unfamiliar namespaces exposed in their code, and if we ever decide to go with a different enum implementation we don't have to worry (as much) about breaking their code.