### PR TITLE
[BUGFIX] Add provided schema under a dummy / internal URI (fixes #376)

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -3,7 +3,6 @@
 namespace JsonSchema;
 
 use JsonSchema\Entity\JsonPointer;
-use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Exception\UnresolvableJsonPointerException;
 use JsonSchema\Iterator\ObjectIterator;
 use JsonSchema\Uri\UriResolver;

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -3,6 +3,7 @@
 namespace JsonSchema;
 
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Exception\UnresolvableJsonPointerException;
 use JsonSchema\Iterator\ObjectIterator;
 use JsonSchema\Uri\UriResolver;
@@ -43,7 +44,10 @@ class SchemaStorage implements SchemaStorageInterface
      */
     public function addSchema($id, $schema = null)
     {
-        if (is_null($schema)) {
+        if (is_null($schema) && $id !== 'internal://provided-schema') {
+            // if the schema was user-provided to Validator and is still null, then assume this is
+            // what the user intended, as there's no way for us to retrieve anything else. User-supplied
+            // schemas do not have an associated URI when passed via Validator::validate().
             $schema = $this->uriRetriever->retrieve($id);
         }
         $objectIterator = new ObjectIterator($schema);

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -10,6 +10,8 @@ use JsonSchema\Uri\UriRetriever;
 
 class SchemaStorage implements SchemaStorageInterface
 {
+    const INTERNAL_PROVIDED_SCHEMA_URI = 'internal://provided-schema';
+
     protected $uriRetriever;
     protected $uriResolver;
     protected $schemas = array();
@@ -43,7 +45,7 @@ class SchemaStorage implements SchemaStorageInterface
      */
     public function addSchema($id, $schema = null)
     {
-        if (is_null($schema) && $id !== 'internal://provided-schema') {
+        if (is_null($schema) && $id !== self::INTERNAL_PROVIDED_SCHEMA_URI) {
             // if the schema was user-provided to Validator and is still null, then assume this is
             // what the user intended, as there's no way for us to retrieve anything else. User-supplied
             // schemas do not have an associated URI when passed via Validator::validate().

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -12,6 +12,7 @@ namespace JsonSchema;
 use JsonSchema\Constraints\BaseConstraint;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\InvalidConfigException;
+use JsonSchema\SchemaStorage;
 
 /**
  * A JsonSchema Constraint
@@ -42,7 +43,7 @@ class Validator extends BaseConstraint
         }
 
         // add provided schema to SchemaStorage with internal URI to allow internal $ref resolution
-        $this->factory->getSchemaStorage()->addSchema('internal://provided-schema', $schema);
+        $this->factory->getSchemaStorage()->addSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI, $schema);
 
         $validator = $this->factory->createInstanceFor('schema');
         $validator->check($value, $schema);

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -41,6 +41,9 @@ class Validator extends BaseConstraint
             $this->factory->setConfig($checkMode);
         }
 
+        // add provided schema to SchemaStorage with internal URI to allow internal $ref resolution
+        $this->factory->getSchemaStorage()->addSchema('internal://provided-schema', $schema);
+
         $validator = $this->factory->createInstanceFor('schema');
         $validator->check($value, $schema);
 

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Tests;
 
 use JsonSchema\SchemaStorage;
 use JsonSchema\Uri\UriRetriever;
+use JsonSchema\Validator;
 use Prophecy\Argument;
 
 class SchemaStorageTest extends \PHPUnit_Framework_TestCase
@@ -29,6 +30,15 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
             (object) array('type' => 'string'),
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house/properties/door")
         );
+    }
+
+    public function testResolveTopRef()
+    {
+        $input = json_decode('{"propertyOne":"notANumber"}');
+        $schema = json_decode('{"$ref":"#/definition","definition":{"properties":{"propertyOne":{"type":"number"}}}}');
+        $v = new Validator();
+        $v->validate($input, $schema);
+        $this->assertFalse($v->isValid());
     }
 
     /**


### PR DESCRIPTION
In order to resolve internal `$ref` references within a user-provided schema, `SchemaStorage` needs to know about the schema. As user-supplied schemas do not have an associated URI, use a dummy / internal one instead.

Fixes issue #376.