### PR TITLE
add quiet option

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -224,7 +224,7 @@ $schema = $refResolver->resolveRef($urlSchema);
 
 if (isset($arOptions['--dump-schema'])) {
     $options = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
-    output(json_encode($schema, $options) . "\n");
+    echo json_encode($schema, $options) . "\n";
     exit();
 }
 

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -210,7 +210,7 @@ try {
     $urlSchema = $resolver->resolve($pathSchema, $urlData);
 
     if (isset($arOptions['--dump-schema-url'])) {
-        output($urlSchema . "\n");
+        echo $urlSchema . "\n";
         exit();
     }
 } catch (Exception $e) {

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -17,7 +17,6 @@ function __autoload($className)
 {
     $className = ltrim($className, '\\');
     $fileName  = '';
-    $namespace = '';
     if ($lastNsPos = strrpos($className, '\\')) {
         $namespace = substr($className, 0, $lastNsPos);
         $className = substr($className, $lastNsPos + 1);
@@ -112,6 +111,7 @@ Usage: validate-json data.json
 Options:
       --dump-schema     Output full schema and exit
       --dump-schema-url Output URL of schema
+      --quiet           Suppress output unless there are errors
    -h --help            Show this help
 
 HLP;
@@ -221,7 +221,9 @@ try {
     $validator->check($data, $schema);
 
     if ($validator->isValid()) {
-        echo "OK. The supplied JSON validates against the schema.\n";
+        if(!isset($arOptions['--quiet'])) {
+            echo "OK. The supplied JSON validates against the schema.\n";
+        }
     } else {
         echo "JSON does not validate. Violations:\n";
         foreach ($validator->getErrors() as $error) {

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -111,7 +111,7 @@ Usage: validate-json data.json
 Options:
       --dump-schema     Output full schema and exit
       --dump-schema-url Output URL of schema
-      --quiet           Suppress output unless there are errors
+      --verbose         Show additional output
    -h --help            Show this help
 
 HLP;
@@ -221,7 +221,7 @@ try {
     $validator->check($data, $schema);
 
     if ($validator->isValid()) {
-        if(!isset($arOptions['--quiet'])) {
+        if(isset($arOptions['--verbose'])) {
             echo "OK. The supplied JSON validates against the schema.\n";
         }
     } else {

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -56,7 +56,7 @@ Options:
       --dump-schema     Output full schema and exit
       --dump-schema-url Output URL of schema
       --verbose         Show additional output
-      --quiet			Supress all output
+      --quiet           Suppress all output
    -h --help            Show this help
 
 HLP;

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -28,6 +28,49 @@ function __autoload($className)
     }
 }
 
+// support running this tool from git checkout
+if (is_dir(__DIR__ . '/../src/JsonSchema')) {
+    set_include_path(__DIR__ . '/../src' . PATH_SEPARATOR . get_include_path());
+}
+
+$arOptions = array();
+$arArgs = array();
+array_shift($argv);//script itself
+foreach ($argv as $arg) {
+    if ($arg{0} == '-') {
+        $arOptions[$arg] = true;
+    } else {
+        $arArgs[] = $arg;
+    }
+}
+
+if (count($arArgs) == 0
+    || isset($arOptions['--help']) || isset($arOptions['-h'])
+) {
+    echo <<<HLP
+Validate schema
+Usage: validate-json data.json
+   or: validate-json data.json schema.json
+
+Options:
+      --dump-schema     Output full schema and exit
+      --dump-schema-url Output URL of schema
+      --verbose         Show additional output
+      --quiet			Supress all output
+   -h --help            Show this help
+
+HLP;
+    exit(1);
+}
+
+if (count($arArgs) == 1) {
+    $pathData   = $arArgs[0];
+    $pathSchema = null;
+} else {
+    $pathData   = $arArgs[0];
+    $pathSchema = getUrlFromPath($arArgs[1]);
+}
+
 /**
  * Show the json parse error that happened last
  *
@@ -43,7 +86,7 @@ function showJsonError()
         }
     }
 
-    echo 'JSON parse error: ' . $json_errors[json_last_error()] . "\n";
+    output('JSON parse error: ' . $json_errors[json_last_error()] . "\n");
 }
 
 function getUrlFromPath($path)
@@ -83,47 +126,16 @@ function parseHeaderValue($headerValue)
     return $arData;
 }
 
-
-// support running this tool from git checkout
-if (is_dir(__DIR__ . '/../src/JsonSchema')) {
-    set_include_path(__DIR__ . '/../src' . PATH_SEPARATOR . get_include_path());
-}
-
-$arOptions = array();
-$arArgs = array();
-array_shift($argv);//script itself
-foreach ($argv as $arg) {
-    if ($arg{0} == '-') {
-        $arOptions[$arg] = true;
-    } else {
-        $arArgs[] = $arg;
+/**
+ * Send a string to the output stream, but only if --quiet is not enabled
+ *
+ * @param $str A string output
+ */
+function output($str) {
+    global $arOptions;
+    if (!isset($arOptions['--quiet'])) {
+        echo $str;
     }
-}
-
-if (count($arArgs) == 0
-    || isset($arOptions['--help']) || isset($arOptions['-h'])
-) {
-    echo <<<HLP
-Validate schema
-Usage: validate-json data.json
-   or: validate-json data.json schema.json
-
-Options:
-      --dump-schema     Output full schema and exit
-      --dump-schema-url Output URL of schema
-      --verbose         Show additional output
-   -h --help            Show this help
-
-HLP;
-    exit(1);
-}
-
-if (count($arArgs) == 1) {
-    $pathData   = $arArgs[0];
-    $pathSchema = null;
-} else {
-    $pathData   = $arArgs[0];
-    $pathSchema = getUrlFromPath($arArgs[1]);
 }
 
 $urlData = getUrlFromPath($pathData);
@@ -141,14 +153,14 @@ $context = stream_context_create(
 );
 $dataString = file_get_contents($pathData, false, $context);
 if ($dataString == '') {
-    echo "Data file is not readable or empty.\n";
+    output("Data file is not readable or empty.\n");
     exit(3);
 }
 
 $data = json_decode($dataString);
 unset($dataString);
 if ($data === null) {
-    echo "Error loading JSON data file\n";
+    output("Error loading JSON data file\n");
     showJsonError();
     exit(5);
 }
@@ -182,9 +194,9 @@ if ($pathSchema === null) {
 
     //autodetect schema
     if ($pathSchema === null) {
-        echo "JSON data must be an object and have a \$schema property.\n";
-        echo "You can pass the schema file on the command line as well.\n";
-        echo "Schema autodetection failed.\n";
+        output("JSON data must be an object and have a \$schema property.\n");
+        output("You can pass the schema file on the command line as well.\n");
+        output("Schema autodetection failed.\n");
         exit(6);
     }
 }
@@ -198,13 +210,13 @@ try {
     $urlSchema = $resolver->resolve($pathSchema, $urlData);
 
     if (isset($arOptions['--dump-schema-url'])) {
-        echo $urlSchema . "\n";
+        output($urlSchema . "\n");
         exit();
     }
 } catch (Exception $e) {
-    echo "Error loading JSON schema file\n";
-    echo $urlSchema . "\n";
-    echo $e->getMessage() . "\n";
+    output("Error loading JSON schema file\n");
+    output($urlSchema . "\n");
+    output($e->getMessage() . "\n");
     exit(2);
 }
 $refResolver = new JsonSchema\SchemaStorage($retriever, $resolver);
@@ -212,7 +224,7 @@ $schema = $refResolver->resolveRef($urlSchema);
 
 if (isset($arOptions['--dump-schema'])) {
     $options = defined('JSON_PRETTY_PRINT') ? JSON_PRETTY_PRINT : 0;
-    echo json_encode($schema, $options) . "\n";
+    output(json_encode($schema, $options) . "\n");
     exit();
 }
 
@@ -222,18 +234,18 @@ try {
 
     if ($validator->isValid()) {
         if(isset($arOptions['--verbose'])) {
-            echo "OK. The supplied JSON validates against the schema.\n";
+            output("OK. The supplied JSON validates against the schema.\n");
         }
     } else {
-        echo "JSON does not validate. Violations:\n";
+        output("JSON does not validate. Violations:\n");
         foreach ($validator->getErrors() as $error) {
-            echo sprintf("[%s] %s\n", $error['property'], $error['message']);
+            output(sprintf("[%s] %s\n", $error['property'], $error['message']));
         }
         exit(23);
     }
 } catch (Exception $e) {
-    echo "JSON does not validate. Error:\n";
-    echo $e->getMessage() . "\n";
-    echo "Error code: " . $e->getCode() . "\n";
+    output("JSON does not validate. Error:\n");
+    output($e->getMessage() . "\n");
+    output("Error code: " . $e->getCode() . "\n");
     exit(24);
 }


### PR DESCRIPTION
Fix for https://github.com/justinrainbow/json-schema/issues/380

Only emit output from CLI when there are errors or when `--quiet` is not specified.

Actually, I'm wondering if maybe we should just skip the `--quiet` option and simply not produce any output at all when validation passes. That's generally how other linux programs work from the command line.

@erayd @bighappyface @evilebottnawi