### PR TITLE
Add option to disable validation of "format" constraint

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ third argument to `Validator::validate()`, or can be provided as the third argum
 | `Constraint::CHECK_MODE_COERCE_TYPES` | Convert data types to match the schema where possible |
 | `Constraint::CHECK_MODE_APPLY_DEFAULTS` | Apply default values from the schema if not set |
 | `Constraint::CHECK_MODE_EXCEPTIONS` | Throw an exception immediately if validation fails |
+| `Constraint::CHECK_MODE_DISABLE_FORMAT` | Do not validate "format" constraints |
 
 Please note that using `Constraint::CHECK_MODE_COERCE_TYPES` or `Constraint::CHECK_MODE_APPLY_DEFAULTS`
 will modify your original data.

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -30,6 +30,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     const CHECK_MODE_COERCE_TYPES =     0x00000004;
     const CHECK_MODE_APPLY_DEFAULTS =   0x00000008;
     const CHECK_MODE_EXCEPTIONS =       0x00000010;
+    const CHECK_MODE_DISABLE_FORMAT =   0x00000020;
 
     /**
      * Bubble down the path

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -27,7 +27,7 @@ class FormatConstraint extends Constraint
      */
     public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
     {
-        if (!isset($schema->format)) {
+        if (!isset($schema->format) || $this->factory->getConfig(self::CHECK_MODE_DISABLE_FORMAT)) {
             return;
         }
 

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -9,6 +9,8 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Constraints\Factory;
 use JsonSchema\Constraints\FormatConstraint;
 
 class FormatTest extends BaseTestCase
@@ -74,6 +76,21 @@ class FormatTest extends BaseTestCase
 
         $validator->check($string, $schema);
         $this->assertEquals(1, count($validator->getErrors()), 'Expected 1 error');
+    }
+
+    /**
+     * @dataProvider getInvalidFormats
+     */
+    public function testDisabledFormat($string, $format)
+    {
+        $factory = new Factory();
+        $validator = new FormatConstraint($factory);
+        $schema = new \stdClass();
+        $schema->format = $format;
+        $factory->addConfig(Constraint::CHECK_MODE_DISABLE_FORMAT);
+
+        $validator->check($string, $schema);
+        $this->assertEmpty($validator->getErrors());
     }
 
     public function getValidFormats()


### PR DESCRIPTION
## What
Add `CHECK_MODE_DISABLE_FORMAT`. If set, validation of the `"format"` keyword is ignored completely, and assumed successful.

## Why
From draft-04 onwards, the spec says we should [provide an option to disable format validation](https://tools.ietf.org/html/draft-wright-json-schema-validation-00#section-7.2):

> Implementations MAY support the "format" keyword.  Should they choose to do so:
     - they SHOULD implement validation for attributes defined below;
     - they SHOULD offer an option to disable validation for this keyword.