### PR TITLE
Improvements to type coercion

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,8 @@ Please note that using `CHECK_MODE_COERCE_TYPES` or `CHECK_MODE_APPLY_DEFAULTS` 
 original data.
 
 `CHECK_MODE_EARLY_COERCE` has no effect unless used in combination with `CHECK_MODE_COERCE_TYPES`. If
-enabled, type coercion will occur as soon as possible, even if the value may already be of another valid
-type.
+enabled, the validator will use (and coerce) the first compatible type it encounters, even if the
+schema defines another type that matches directly and does not require coercion.
 
 ## Running the tests
 

--- a/README.md
+++ b/README.md
@@ -186,14 +186,19 @@ third argument to `Validator::validate()`, or can be provided as the third argum
 | `Constraint::CHECK_MODE_NORMAL` | Validate in 'normal' mode - this is the default |
 | `Constraint::CHECK_MODE_TYPE_CAST` | Enable fuzzy type checking for associative arrays and objects |
 | `Constraint::CHECK_MODE_COERCE_TYPES` | Convert data types to match the schema where possible |
+| `Constraint::CHECK_MODE_EARLY_COERCE` | Apply type coercion as soon as possible |
 | `Constraint::CHECK_MODE_APPLY_DEFAULTS` | Apply default values from the schema if not set |
 | `Constraint::CHECK_MODE_ONLY_REQUIRED_DEFAULTS` | When applying defaults, only set values that are required |
 | `Constraint::CHECK_MODE_EXCEPTIONS` | Throw an exception immediately if validation fails |
 | `Constraint::CHECK_MODE_DISABLE_FORMAT` | Do not validate "format" constraints |
 | `Constraint::CHECK_MODE_VALIDATE_SCHEMA` | Validate the schema as well as the provided document |
 
-Please note that using `Constraint::CHECK_MODE_COERCE_TYPES` or `Constraint::CHECK_MODE_APPLY_DEFAULTS`
-will modify your original data.
+Please note that using `CHECK_MODE_COERCE_TYPES` or `CHECK_MODE_APPLY_DEFAULTS` will modify your
+original data.
+
+`CHECK_MODE_EARLY_COERCE` has no effect unless used in combination with `CHECK_MODE_COERCE_TYPES`. If
+enabled, type coercion will occur as soon as possible, even if the value may already be of another valid
+type.
 
 ## Running the tests
 

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -31,6 +31,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     const CHECK_MODE_APPLY_DEFAULTS =   0x00000008;
     const CHECK_MODE_EXCEPTIONS =       0x00000010;
     const CHECK_MODE_DISABLE_FORMAT =   0x00000020;
+    const CHECK_MODE_EARLY_COERCE =     0x00000040;
     const CHECK_MODE_ONLY_REQUIRED_DEFAULTS   = 0x00000080;
     const CHECK_MODE_VALIDATE_SCHEMA =  0x00000100;
 

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -45,11 +45,12 @@ class TypeConstraint extends Constraint
         $type = isset($schema->type) ? $schema->type : null;
         $isValid = false;
         $coerce = $this->factory->getConfig(self::CHECK_MODE_COERCE_TYPES);
+        $earlyCoerce = $this->factory->getConfig(self::CHECK_MODE_EARLY_COERCE);
         $wording = array();
 
         if (is_array($type)) {
-            $this->validateTypesArray($value, $type, $wording, $isValid, $path, false);
-            if (!$isValid && $coerce) {
+            $this->validateTypesArray($value, $type, $wording, $isValid, $path, $coerce && $earlyCoerce);
+            if (!$isValid && $coerce && !$earlyCoerce) {
                 $this->validateTypesArray($value, $type, $wording, $isValid, $path, true);
             }
         } elseif (is_object($type)) {
@@ -57,8 +58,8 @@ class TypeConstraint extends Constraint
 
             return;
         } else {
-            $isValid = $this->validateType($value, $type, false);
-            if (!$isValid && $coerce) {
+            $isValid = $this->validateType($value, $type, $coerce && $earlyCoerce);
+            if (!$isValid && $coerce && !$earlyCoerce) {
                 $isValid = $this->validateType($value, $type, true);
             }
         }

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -82,6 +82,11 @@ class TypeConstraint extends Constraint
     protected function validateTypesArray(&$value, array $type, &$validTypesWording, &$isValid, $path)
     {
         foreach ($type as $tp) {
+            // already valid, so no need to waste cycles looping over everything
+            if ($isValid) {
+                return;
+            }
+
             // $tp can be an object, if it's a schema instead of a simple type, validate it
             // with a new type constraint
             if (is_object($tp)) {

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -175,9 +175,10 @@ class CoerciveTest extends VeryBaseTestCase
 
         // check validity
         if ($valid) {
+            $prettyPrint = defined('\JSON_PRETTY_PRINT') ? constant('\JSON_PRETTY_PRINT') : 0;
             $this->assertTrue(
                 $validator->isValid(),
-                'Validation failed: ' . json_encode($validator->getErrors(), \JSON_PRETTY_PRINT)
+                'Validation failed: ' . json_encode($validator->getErrors(), $prettyPrint)
             );
 
             // check end type

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -48,50 +48,44 @@ class CoerciveTest extends VeryBaseTestCase
                 array('NULL',       'null',         0,              true),  // #12
                 array('array',      '["-45"]',      -45,            true),  // #13
                 array('object',     '{"a":"b"}',    null,           false), // #14
+                array('array',      '["ABC"]',      null,           false), // #15
             ),
             'boolean' => array(
-                array('string',     '"true"',       true,           true),  // #15
-                array('integer',    '1',            true,           true),  // #16
-                array('boolean',    'true',         true,           true),  // #17
-                array('NULL',       'null',         false,          true),  // #18
-                array('array',      '["true"]',     true,           true),  // #19
-                array('object',     '{"a":"b"}',    null,           false), // #20
-                array('string',     '""',           null,           false), // #21
-                array('string',     '"ABC"',        null,           false), // #22
-                array('integer',    '2',            null,           false), // #23
+                array('string',     '"true"',       true,           true),  // #16
+                array('integer',    '1',            true,           true),  // #17
+                array('boolean',    'true',         true,           true),  // #18
+                array('NULL',       'null',         false,          true),  // #19
+                array('array',      '["true"]',     true,           true),  // #20
+                array('object',     '{"a":"b"}',    null,           false), // #21
+                array('string',     '""',           null,           false), // #22
+                array('string',     '"ABC"',        null,           false), // #23
+                array('integer',    '2',            null,           false), // #24
             ),
             'NULL' => array(
-                array('string',     '""',           null,           true),  // #24
-                array('integer',    '0',            null,           true),  // #25
-                array('boolean',    'false',        null,           true),  // #26
-                array('NULL',       'null',         null,           true),  // #27
-                array('array',      '[0]',          null,           true),  // #28
-                array('object',     '{"a":"b"}',    null,           false), // #29
-                array('string',     '"null"',       null,           false), // #30
-                array('integer',    '-1',           null,           false), // #31
+                array('string',     '""',           null,           true),  // #25
+                array('integer',    '0',            null,           true),  // #26
+                array('boolean',    'false',        null,           true),  // #27
+                array('NULL',       'null',         null,           true),  // #28
+                array('array',      '[0]',          null,           true),  // #29
+                array('object',     '{"a":"b"}',    null,           false), // #30
+                array('string',     '"null"',       null,           false), // #31
+                array('integer',    '-1',           null,           false), // #32
             ),
             'array' => array(
-                array('string',     '"ABC"',        array('ABC'),   true),  // #32
-                array('integer',    '45',           array(45),      true),  // #33
-                array('boolean',    'true',         array(true),    true),  // #34
-                array('NULL',       'null',         array(null),    true),  // #35
-                array('array',      '["ABC"]',      array('ABC'),   true),  // #36
-                array('object',     '{"a":"b"}',    null,           false), // #37
+                array('string',     '"ABC"',        array('ABC'),   true),  // #33
+                array('integer',    '45',           array(45),      true),  // #34
+                array('boolean',    'true',         array(true),    true),  // #35
+                array('NULL',       'null',         array(null),    true),  // #36
+                array('array',      '["ABC"]',      array('ABC'),   true),  // #37
+                array('object',     '{"a":"b"}',    null,           false), // #38
             ),
         );
 
-        // #38 check post-coercion validation (to array)
+        // #39 check post-coercion validation (to array)
         $tests[] = array(
             '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"}]}}}',
             '{"propertyOne":"ABC"}',
             'string', null, null, false
-        );
-
-        // #39 check post-coercion validation (from array)
-        $tests[] = array(
-            '{"properties":{"propertyOne":{"type":"number"}}}',
-            '{"propertyOne":["ABC"]}',
-            'array', null, null, false
         );
 
         // #40 check multiple types (first valid)

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -31,7 +31,7 @@ class CoerciveTest extends VeryBaseTestCase
             // toType
             'string' => array(
                 //    fromType      fromValue       toValue         valid   Test Number
-                array('string',     '"string"',     'string',       true),  // #0
+                array('string',     '"ABC"',        'ABC',          true),  // #0
                 array('integer',    '45',           '45',           true),  // #1
                 array('boolean',    'true',         'true',         true),  // #2
                 array('boolean',    'false',        'false',        true),  // #3
@@ -55,7 +55,7 @@ class CoerciveTest extends VeryBaseTestCase
                 array('boolean',    'true',         true,           true),  // #17
                 array('NULL',       'null',         false,          true),  // #18
                 array('array',      '["true"]',     true,           true),  // #19
-                array('object',     '{"a":"b"}',     null,          false), // #20
+                array('object',     '{"a":"b"}',    null,           false), // #20
                 array('string',     '""',           null,           false), // #21
                 array('string',     '"ABC"',        null,           false), // #22
                 array('integer',    '2',            null,           false), // #23
@@ -140,7 +140,7 @@ class CoerciveTest extends VeryBaseTestCase
         $tests[] = array(
             '{"properties":{"propertyOne":{"type":["object", "number", "string"]}}}',
             '{"propertyOne":"42"}',
-            'string', 'integer', 42, true, true
+            'string', 'integer', 42, true, Constraint::CHECK_MODE_EARLY_COERCE
         );
 
         // #45 check multiple types (none valid)
@@ -154,11 +154,8 @@ class CoerciveTest extends VeryBaseTestCase
     }
 
     /** @dataProvider dataCoerceCases **/
-    public function testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $early = false, $assoc = false)
+    public function testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $extraFlags = 0, $assoc = false)
     {
-        if ($early) {
-            $this->factory->addConfig(Constraint::CHECK_MODE_EARLY_COERCE);
-        }
         $validator = new Validator($this->factory);
 
         $schema = json_decode($schema);
@@ -171,7 +168,7 @@ class CoerciveTest extends VeryBaseTestCase
         }
         $this->assertEquals($startType, $type, "Incorrect type '$type': expected '$startType'");
 
-        $validator->validate($data, $schema);
+        $validator->validate($data, $schema, $this->factory->getConfig() | $extraFlags);
 
         // check validity
         if ($valid) {
@@ -199,8 +196,6 @@ class CoerciveTest extends VeryBaseTestCase
             $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed');
             $this->assertEquals(1, count($validator->getErrors()));
         }
-
-        $this->factory->removeConfig(Constraint::CHECK_MODE_EARLY_COERCE);
     }
 
     /** @dataProvider dataCoerceCases **/

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -136,12 +136,22 @@ class CoerciveTest extends VeryBaseTestCase
             'array', 'array', array(42, '42'), true
         );
 
+        // #44 check early coercion
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":["object", "number", "string"]}}}',
+            '{"propertyOne":"42"}',
+            'string', 'integer', 42, true, true
+        );
+
         return $tests;
     }
 
     /** @dataProvider dataCoerceCases **/
-    public function testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $assoc = false)
+    public function testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $early = false, $assoc = false)
     {
+        if ($early) {
+            $this->factory->addConfig(Constraint::CHECK_MODE_EARLY_COERCE);
+        }
         $validator = new Validator($this->factory);
 
         $schema = json_decode($schema);
@@ -181,12 +191,14 @@ class CoerciveTest extends VeryBaseTestCase
             $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed');
             $this->assertEquals(1, count($validator->getErrors()));
         }
+
+        $this->factory->removeConfig(Constraint::CHECK_MODE_EARLY_COERCE);
     }
 
     /** @dataProvider dataCoerceCases **/
-    public function testCoerceCasesUsingAssoc($schema, $data, $startType, $endType, $endValue, $valid)
+    public function testCoerceCasesUsingAssoc($schema, $data, $startType, $endType, $endValue, $valid, $early = false)
     {
-        $this->testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, true);
+        $this->testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $early, true);
     }
 
     public function testCoerceAPI()

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -143,6 +143,13 @@ class CoerciveTest extends VeryBaseTestCase
             'string', 'integer', 42, true, true
         );
 
+        // #45 check multiple types (none valid)
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":["number", "boolean"]}}}',
+            '{"propertyOne":"42"}',
+            'string', 'integer', 42, true
+        );
+
         return $tests;
     }
 

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -11,113 +11,182 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
-use JsonSchema\SchemaStorage;
-use JsonSchema\Uri\UriResolver;
+use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Validator;
 
-class CoerciveTest extends BasicTypesTest
+class CoerciveTest extends VeryBaseTestCase
 {
-    protected $schemaSpec = 'http://json-schema.org/draft-03/schema#';
-    protected $validateSchema = true;
+    protected $factory = null;
 
-    /**
-     * @dataProvider getValidCoerceTests
-     */
-    public function testValidCoerceCasesUsingAssoc($input, $schema)
+    public function setUp()
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
-
-        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
-        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
-
-        $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-
-        $value = json_decode($input, true);
-
-        $validator->validate($value, $schema, $checkMode);
-        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
+        $this->factory = new Factory();
+        $this->factory->setConfig(Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES);
     }
 
-    /**
-     * @dataProvider getValidCoerceTests
-     */
-    public function testValidCoerceCases($input, $schema, $errors = array())
+    public function dataCoerceCases()
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
+        // check type conversions
+        $types = array(
+            // toType
+            'string' => array(
+                //    fromType      fromValue       toValue         valid   Test Number
+                array('string',     '"string"',     'string',       true),  // #0
+                array('integer',    '45',           '45',           true),  // #1
+                array('boolean',    'true',         'true',         true),  // #2
+                array('boolean',    'false',        'false',        true),  // #3
+                array('NULL',       'null',         '',             true),  // #4
+                array('array',      '[45]',         '45',           true),  // #5
+                array('object',     '{"a":"b"}',    null,           false), // #6
+                array('array',      '[{"a":"b"}]',  null,           false), // #7
+            ),
+            'integer' => array(
+                array('string',     '"45"',         45,             true),  // #8
+                array('integer',    '45',           45,             true),  // #9
+                array('boolean',    'true',         1,              true),  // #10
+                array('boolean',    'false',        0,              true),  // #11
+                array('NULL',       'null',         0,              true),  // #12
+                array('array',      '["-45"]',      -45,            true),  // #13
+                array('object',     '{"a":"b"}',    null,           false), // #14
+            ),
+            'boolean' => array(
+                array('string',     '"true"',       true,           true),  // #15
+                array('integer',    '1',            true,           true),  // #16
+                array('boolean',    'true',         true,           true),  // #17
+                array('NULL',       'null',         false,          true),  // #18
+                array('array',      '["true"]',     true,           true),  // #19
+                array('object',     '{"a":"b"}',     null,          false), // #20
+                array('string',     '""',           null,           false), // #21
+                array('string',     '"ABC"',        null,           false), // #22
+                array('integer',    '2',            null,           false), // #23
+            ),
+            'NULL' => array(
+                array('string',     '""',           null,           true),  // #24
+                array('integer',    '0',            null,           true),  // #25
+                array('boolean',    'false',        null,           true),  // #26
+                array('NULL',       'null',         null,           true),  // #27
+                array('array',      '[0]',          null,           true),  // #28
+                array('object',     '{"a":"b"}',    null,           false), // #29
+                array('string',     '"null"',       null,           false), // #30
+                array('integer',    '-1',           null,           false), // #31
+            ),
+            'array' => array(
+                array('string',     '"ABC"',        array('ABC'),   true),  // #32
+                array('integer',    '45',           array(45),      true),  // #33
+                array('boolean',    'true',         array(true),    true),  // #34
+                array('NULL',       'null',         array(null),    true),  // #35
+                array('array',      '["ABC"]',      array('ABC'),   true),  // #36
+                array('object',     '{"a":"b"}',    null,           false), // #37
+            ),
+        );
 
-        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
-        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
-
-        $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $value = json_decode($input);
-
-        $this->assertTrue(gettype($value->number) == 'string');
-        $this->assertTrue(gettype($value->integer) == 'string');
-        $this->assertTrue(gettype($value->boolean) == 'string');
-
-        $validator->validate($value, $schema, $checkMode);
-
-        $this->assertTrue(gettype($value->number) == 'double');
-        $this->assertTrue(gettype($value->integer) == 'integer');
-        $this->assertTrue(gettype($value->negativeInteger) == 'integer');
-        $this->assertTrue(gettype($value->boolean) == 'boolean');
-
-        $this->assertTrue($value->number === 1.5);
-        $this->assertTrue($value->integer === 1);
-        $this->assertTrue($value->negativeInteger === -2);
-        $this->assertTrue($value->boolean === true);
-
-        $this->assertTrue(gettype($value->multitype1) == 'boolean');
-        $this->assertTrue(gettype($value->multitype2) == 'double');
-        $this->assertTrue(gettype($value->multitype3) == 'integer');
-        $this->assertTrue(gettype($value->multitype4) == 'string');
-
-        $this->assertTrue($value->number === 1.5);
-        $this->assertTrue($value->integer === 1);
-        $this->assertTrue($value->negativeInteger === -2);
-        $this->assertTrue($value->boolean === true);
-
-        $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
-    }
-
-    /**
-     * @dataProvider getInvalidCoerceTests
-     */
-    public function testInvalidCoerceCases($input, $schema, $errors = array())
-    {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
-
-        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
-        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
-
-        $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $value = json_decode($input);
-        $validator->validate($value, $schema, $checkMode);
-
-        if (array() !== $errors) {
-            $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
+        $tests = array();
+        foreach ($types as $toType => $testCases) {
+            foreach ($testCases as $testCase) {
+                $tests[] = array(
+                    sprintf('{"properties":{"propertyOne":{"type":"%s"}}}', strtolower($toType)),
+                    sprintf('{"propertyOne":%s}', $testCase[1]),
+                    $testCase[0],
+                    $toType,
+                    $testCase[2],
+                    $testCase[3]
+                );
+            }
         }
-        $this->assertFalse($validator->isValid(), print_r($validator->getErrors(), true));
+
+        // #38 check post-coercion validation (to array)
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"}]}}}',
+            '{"propertyOne":"ABC"}',
+            'string', null, null, false
+        );
+
+        // #39 check post-coercion validation (from array)
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"number"}}}',
+            '{"propertyOne":["ABC"]}',
+            'array', null, null, false
+        );
+
+        // #40 check multiple types (first valid)
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":["number", "string"]}}}',
+            '{"propertyOne":42}',
+            'integer', 'integer', 42, true
+        );
+
+        // #41 check multiple types (last valid)
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":["number", "string"]}}}',
+            '{"propertyOne":"42"}',
+            'string', 'string', '42', true
+        );
+
+        // #42 check the meaning of life
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"any"}}}',
+            '{"propertyOne":"42"}',
+            'string', 'string', '42', true
+        );
+
+        // #43 check turple coercion
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"},{"type":"string"}]}}}',
+            '{"propertyOne":["42", 42]}',
+            'array', 'array', array(42, '42'), true
+        );
+
+        return $tests;
     }
 
-    /**
-     * @dataProvider getInvalidCoerceTests
-     */
-    public function testInvalidCoerceCasesUsingAssoc($input, $schema, $errors = array())
+    /** @dataProvider dataCoerceCases **/
+    public function testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, $assoc = false)
     {
-        $checkMode = Constraint::CHECK_MODE_TYPE_CAST | Constraint::CHECK_MODE_COERCE_TYPES;
+        $validator = new Validator($this->factory);
 
-        $schemaStorage = new SchemaStorage($this->getUriRetrieverMock(json_decode($schema)));
-        $schema = $schemaStorage->getSchema('http://www.my-domain.com/schema.json');
+        $schema = json_decode($schema);
+        $data = json_decode($data, $assoc);
 
-        $validator = new Validator(new Factory($schemaStorage, null, $checkMode));
-        $value = json_decode($input, true);
-        $validator->validate($value, $schema, $checkMode);
-
-        if (array() !== $errors) {
-            $this->assertEquals($errors, $validator->getErrors(), print_r($validator->getErrors(), true));
+        // check initial type
+        $type = gettype(LooseTypeCheck::propertyGet($data, 'propertyOne'));
+        if ($assoc && $type == 'array' && $startType == 'object') {
+            $type = 'object';
         }
-        $this->assertFalse($validator->isValid(), print_r($validator->getErrors(), true));
+        $this->assertEquals($startType, $type, "Incorrect type '$type': expected '$startType'");
+
+        $validator->validate($data, $schema);
+
+        // check validity
+        if ($valid) {
+            $this->assertTrue(
+                $validator->isValid(),
+                'Validation failed: ' . json_encode($validator->getErrors(), \JSON_PRETTY_PRINT)
+            );
+
+            // check end type
+            $type = gettype(LooseTypeCheck::propertyGet($data, 'propertyOne'));
+            $this->assertEquals($endType, $type, "Incorrect type '$type': expected '$endType'");
+
+            // check end value
+            $value = LooseTypeCheck::propertyGet($data, 'propertyOne');
+            $this->assertTrue(
+                $value === $endValue,
+                sprintf(
+                    "Incorrect value '%s': expected '%s'",
+                    is_scalar($value) ? $value : gettype($value),
+                    is_scalar($endValue) ? $endValue : gettype($endValue)
+                )
+            );
+        } else {
+            $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed');
+            $this->assertEquals(1, count($validator->getErrors()));
+        }
+    }
+
+    /** @dataProvider dataCoerceCases **/
+    public function testCoerceCasesUsingAssoc($schema, $data, $startType, $endType, $endValue, $valid)
+    {
+        $this->testCoerceCases($schema, $data, $startType, $endType, $endValue, $valid, true);
     }
 
     public function testCoerceAPI()
@@ -127,170 +196,5 @@ class CoerciveTest extends BasicTypesTest
         $v = new Validator();
         $v->coerce($input, $schema);
         $this->assertEquals('{"propertyOne":10}', json_encode($input));
-    }
-
-    public function getValidCoerceTests()
-    {
-        return array(
-            array(
-                '{
-                  "string":"string test",
-                  "number":"1.5",
-                  "integer":"1",
-                  "negativeInteger":"-2",
-                  "boolean":"true",
-                  "object":{},
-                  "array":[],
-                  "null":null,
-                  "any": "string",
-                  "allOf": "1",
-                  "multitype1": "false",
-                  "multitype2": "1.2",
-                  "multitype3": "7",
-                  "multitype4": "45",
-                  "arrayOfIntegers":["-1","0","1"],
-                  "tupleTyping":["1","2.2","true"],
-                  "any1": 2.6,
-                  "any2": 4,
-                  "any3": false,
-                  "any4": {},
-                  "any5": [],
-                  "any6": null
-                }',
-                '{
-                  "type":"object",
-                  "properties":{
-                    "string":{"type":"string"},
-                    "number":{"type":"number"},
-                    "integer":{"type":"integer"},
-                    "negativeInteger":{"type":"integer"},
-                    "boolean":{"type":"boolean"},
-                    "object":{"type":"object"},
-                    "array":{"type":"array"},
-                    "null":{"type":"null"},
-                    "any": {"type":"any"},
-                    "allOf" : {"allOf":[{
-                        "type" : "string"
-                    },{
-                        "type" : "integer"
-                    }]},
-                    "multitype1": {"type":["boolean","integer","number"]},
-                    "multitype2": {"type":["boolean","integer","number"]},
-                    "multitype3": {"type":["boolean","integer","number"]},
-                    "multitype4": {"type":["boolean","integer","string"]},
-                     "arrayOfIntegers":{
-                        "items":{
-                            "type":"integer"
-                        }
-                    },
-                    "tupleTyping":{
-                      "type":"array",
-                      "items":[
-                        {"type":"integer"},
-                        {"type":"number"}
-                      ],
-                      "additionalItems":{"type":"boolean"}
-                    },
-                    "any1": {"type":"any"},
-                    "any2": {"type":"any"},
-                    "any3": {"type":"any"},
-                    "any4": {"type":"any"},
-                    "any5": {"type":"any"},
-                    "any6": {"type":"any"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-        );
-    }
-
-    public function getInvalidCoerceTests()
-    {
-        return array(
-            array(
-                '{
-                  "string":null
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "string":{"type":"string"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "number":"five"
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "number":{"type":"number"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "integer":"5.2"
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "integer":{"type":"integer"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "boolean":"0"
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "boolean":{"type":"boolean"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "object":null
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "object":{"type":"object"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "array":null
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "array":{"type":"array"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-            array(
-                '{
-                  "null":1
-                }',
-                '{
-                  "type":"object",
-                  "properties": {
-                    "null":{"type":"null"}
-                  },
-                  "additionalProperties":false
-                }',
-            ),
-        );
     }
 }

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -70,6 +70,7 @@ class CoerciveTest extends BasicTypesTest
         $this->assertTrue(gettype($value->multitype1) == 'boolean');
         $this->assertTrue(gettype($value->multitype2) == 'double');
         $this->assertTrue(gettype($value->multitype3) == 'integer');
+        $this->assertTrue(gettype($value->multitype4) == 'string');
 
         $this->assertTrue($value->number === 1.5);
         $this->assertTrue($value->integer === 1);
@@ -146,6 +147,7 @@ class CoerciveTest extends BasicTypesTest
                   "multitype1": "false",
                   "multitype2": "1.2",
                   "multitype3": "7",
+                  "multitype4": "45",
                   "arrayOfIntegers":["-1","0","1"],
                   "tupleTyping":["1","2.2","true"],
                   "any1": 2.6,
@@ -175,6 +177,7 @@ class CoerciveTest extends BasicTypesTest
                     "multitype1": {"type":["boolean","integer","number"]},
                     "multitype2": {"type":["boolean","integer","number"]},
                     "multitype3": {"type":["boolean","integer","number"]},
+                    "multitype4": {"type":["boolean","integer","string"]},
                      "arrayOfIntegers":{
                         "items":{
                             "type":"integer"

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -80,20 +80,6 @@ class CoerciveTest extends VeryBaseTestCase
             ),
         );
 
-        $tests = array();
-        foreach ($types as $toType => $testCases) {
-            foreach ($testCases as $testCase) {
-                $tests[] = array(
-                    sprintf('{"properties":{"propertyOne":{"type":"%s"}}}', strtolower($toType)),
-                    sprintf('{"propertyOne":%s}', $testCase[1]),
-                    $testCase[0],
-                    $toType,
-                    $testCase[2],
-                    $testCase[3]
-                );
-            }
-        }
-
         // #38 check post-coercion validation (to array)
         $tests[] = array(
             '{"properties":{"propertyOne":{"type":"array","items":[{"type":"number"}]}}}',
@@ -149,6 +135,20 @@ class CoerciveTest extends VeryBaseTestCase
             '{"propertyOne":"42"}',
             'string', 'integer', 42, true
         );
+
+        $tests = array();
+        foreach ($types as $toType => $testCases) {
+            foreach ($testCases as $testCase) {
+                $tests[] = array(
+                    sprintf('{"properties":{"propertyOne":{"type":"%s"}}}', strtolower($toType)),
+                    sprintf('{"propertyOne":%s}', $testCase[1]),
+                    $testCase[0],
+                    $toType,
+                    $testCase[2],
+                    $testCase[3]
+                );
+            }
+        }
 
         return $tests;
     }

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -83,8 +83,8 @@ class OfPropertiesTest extends BaseTestCase
                         'constraint' => array(
                             'name' => 'type',
                             'params' => array(
-                                'expected'   => 'array',
-                                'found'      => 'a string'
+                                'expected'   => 'a string',
+                                'found'      => 'array'
                             )
                         ),
                         'context'    => Validator::ERROR_DOCUMENT_VALIDATION
@@ -96,8 +96,8 @@ class OfPropertiesTest extends BaseTestCase
                         'constraint' => array(
                             'name' => 'type',
                             'params' => array(
-                                'expected'   => 'array',
-                                'found'      => 'a number'
+                                'expected'   => 'a number',
+                                'found'      => 'array'
                             )
                         ),
                         'context'    => Validator::ERROR_DOCUMENT_VALIDATION


### PR DESCRIPTION
## What
 * Don't coerce already-valid types
 * Add `CHECK_MODE_EARLY_COERCE` to enable previous coercion behavior
 * Don't test further types if we've already validated one successfully
 * Fix reversed arguments from #364 
 * Implement every remaining coercion case from [ajv's matrix](https://github.com/epoberezkin/ajv/blob/master/COERCION.md)
 * Rewrite coercion tests to improve readability and simplify adding future tests.

## Why
See discussion in #379 regarding coercion of already-valid types and `CHECK_MODE_EARLY_COERCE`. Other items are performance / bugfix, or are to improve testing.