### PR TITLE
Reset errors prior to validation

### DIFF
--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -37,6 +37,10 @@ class Validator extends BaseConstraint
      */
     public function validate(&$value, $schema = null, $checkMode = null)
     {
+        // reset errors prior to validation
+        $this->reset();
+
+        // set checkMode
         $initialCheckMode = $this->factory->getConfig();
         if ($checkMode !== null) {
             $this->factory->setConfig($checkMode);


### PR DESCRIPTION
## What
Call `Validator::reset()` prior to validation.

## Why
Allows a validator object to be reused following a failing validation, without the user needing to call `Validator::reset()` manually. Addresses #385. 