### PR TITLE
Allow the schema to be an associative array

### DIFF
--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -12,6 +12,7 @@ namespace JsonSchema\Constraints;
 use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Exception\ValidationException;
 
 /**
@@ -100,12 +101,15 @@ class BaseConstraint
      */
     public static function arrayToObjectRecursive($array)
     {
-        foreach ($array as &$value) {
-            if (is_array($value)) {
-                $value = self::arrayToObjectRecursive($value);
+        $json = json_encode($array);
+        if (json_last_error() !== \JSON_ERROR_NONE) {
+            $message = 'Unable to encode schema array as JSON';
+            if (version_compare(phpversion(), '5.5.0', '>=')) {
+                $message .= ': ' . json_last_error_msg();
             }
+            throw new InvalidArgumentException($message);
         }
 
-        return LooseTypeCheck::isObject($array) ? (object) $array : $array;
+        return json_decode($json);
     }
 }

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -10,6 +10,7 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\ConstraintError;
+use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\ValidationException;
 
@@ -88,5 +89,23 @@ class BaseConstraint
     public function reset()
     {
         $this->errors = array();
+    }
+
+    /**
+     * Recursively cast an associative array to an object
+     *
+     * @param array $array
+     *
+     * @return object
+     */
+    public static function arrayToObjectRecursive($array)
+    {
+        foreach ($array as &$value) {
+            if (is_array($value)) {
+                $value = self::arrayToObjectRecursive($value);
+            }
+        }
+
+        return LooseTypeCheck::isObject($array) ? (object) $array : $array;
     }
 }

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -40,6 +40,11 @@ class Validator extends BaseConstraint
         // reset errors prior to validation
         $this->reset();
 
+        // make sure $schema is an object
+        if (is_array($schema)) {
+            $schema = self::arrayToObjectRecursive($schema);
+        }
+
         // set checkMode
         $initialCheckMode = $this->factory->getConfig();
         if ($checkMode !== null) {

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace JsonSchema\Tests;
+
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Validator;
+
+class ValidatorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testValidateWithAssocSchema()
+    {
+        $schema = json_decode('{"properties":{"propertyOne":{"type":"array","items":[{"type":"string"}]}}}', true);
+        $data = json_decode('{"propertyOne":[42]}', true);
+
+        $validator = new Validator();
+        $validator->validate($data, $schema);
+
+        $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed.');
+    }
+
+    public function testCheck()
+    {
+        $schema = json_decode('{"type":"string"}');
+        $data = json_decode('42');
+
+        $validator = new Validator();
+        $validator->check($data, $schema);
+
+        $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed.');
+    }
+
+    public function testCoerce()
+    {
+        $schema = json_decode('{"type":"integer"}');
+        $data = json_decode('"42"');
+
+        $validator = new Validator();
+        $validator->coerce($data, $schema);
+
+        $this->assertTrue($validator->isValid(), 'Validation failed, but should have succeeded.');
+    }
+}

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -23,6 +23,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         if (version_compare(phpversion(), '5.5.0', '<')) {
             $this->markTestSkipped('PHP versions < 5.5.0 trigger an error on json_encode issues');
         }
+        if (defined('HHVM_VERSION')) {
+            $this->markTestSkipped('HHVM has no problem with encoding resources');
+        }
         $schema = array('propertyOne' => fopen('php://stdout', 'w'));
         $data = json_decode('{"propertyOne":[42]}', true);
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -18,6 +18,17 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed.');
     }
 
+    public function testBadAssocSchemaInput()
+    {
+        $schema = array('propertyOne' => fopen('php://stdout', 'w'));
+        $data = json_decode('{"propertyOne":[42]}', true);
+
+        $validator = new Validator();
+
+        $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
+        $validator->validate($data, $schema);
+    }
+
     public function testCheck()
     {
         $schema = json_decode('{"type":"string"}');

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -20,6 +20,9 @@ class ValidatorTest extends \PHPUnit_Framework_TestCase
 
     public function testBadAssocSchemaInput()
     {
+        if (version_compare(phpversion(), '5.5.0', '<')) {
+            $this->markTestSkipped('PHP versions < 5.5.0 trigger an error on json_encode issues');
+        }
         $schema = array('propertyOne' => fopen('php://stdout', 'w'));
         $data = json_decode('{"propertyOne":[42]}', true);
 


### PR DESCRIPTION
## What
If the schema supplied to `Validator::validate` is an array, convert it to an object prior to using it for validation.

## Why
Because it was requested in #388, and will improve the user-friendliness of the library interface, particularly noting we already support the data to be validated being an associative array.