### PR TITLE
[BUGFIX] Don't throw exceptions until after checking anyOf / oneOf

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -12,6 +12,7 @@ namespace JsonSchema\Constraints;
 use JsonSchema\ConstraintError;
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Entity\JsonPointer;
+use JsonSchema\Exception\ValidationException;
 use JsonSchema\Uri\UriResolver;
 
 /**
@@ -245,11 +246,16 @@ class UndefinedConstraint extends Constraint
         if (isset($schema->anyOf)) {
             $isValid = false;
             $startErrors = $this->getErrors();
+            $caughtException = null;
             foreach ($schema->anyOf as $anyOf) {
                 $initErrors = $this->getErrors();
-                $this->checkUndefined($value, $anyOf, $path, $i);
-                if ($isValid = (count($this->getErrors()) == count($initErrors))) {
-                    break;
+                try {
+                    $this->checkUndefined($value, $anyOf, $path, $i);
+                    if ($isValid = (count($this->getErrors()) == count($initErrors))) {
+                        break;
+                    }
+                } catch (ValidationException $e) {
+                    $isValid = false;
                 }
             }
             if (!$isValid) {
@@ -264,12 +270,17 @@ class UndefinedConstraint extends Constraint
             $matchedSchemas = 0;
             $startErrors = $this->getErrors();
             foreach ($schema->oneOf as $oneOf) {
-                $this->errors = array();
-                $this->checkUndefined($value, $oneOf, $path, $i);
-                if (count($this->getErrors()) == 0) {
-                    $matchedSchemas++;
+                try {
+                    $this->errors = array();
+                    $this->checkUndefined($value, $oneOf, $path, $i);
+                    if (count($this->getErrors()) == 0) {
+                        $matchedSchemas++;
+                    }
+                    $allErrors = array_merge($allErrors, array_values($this->getErrors()));
+                } catch (ValidationException $e) {
+                    // deliberately do nothing here - validation failed, but we want to check
+                    // other schema options in the OneOf field.
                 }
-                $allErrors = array_merge($allErrors, array_values($this->getErrors()));
             }
             if ($matchedSchemas !== 1) {
                 $this->addErrors(array_merge($allErrors, $startErrors));

--- a/tests/Constraints/OfPropertiesTest.php
+++ b/tests/Constraints/OfPropertiesTest.php
@@ -8,6 +8,9 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\Constraints\Constraint;
+use JsonSchema\Validator;
+
 /**
  * Class OfPropertiesTest
  */
@@ -222,5 +225,45 @@ class OfPropertiesTest extends BaseTestCase
                 }'
             )
         );
+    }
+
+    public function testNoPrematureAnyOfException()
+    {
+        $schema = json_decode('{
+            "type": "object",
+            "properties": {
+                "propertyOne": {
+                    "anyOf": [
+                        {"type": "number"},
+                        {"type": "string"}
+                    ]
+                }
+            }
+        }');
+        $data = json_decode('{"propertyOne":"ABC"}');
+
+        $v = new Validator();
+        $v->validate($data, $schema, Constraint::CHECK_MODE_EXCEPTIONS);
+        $this->assertTrue($v->isValid());
+    }
+
+    public function testNoPrematureOneOfException()
+    {
+        $schema = json_decode('{
+            "type": "object",
+            "properties": {
+                "propertyOne": {
+                    "oneOf": [
+                        {"type": "number"},
+                        {"type": "string"}
+                    ]
+                }
+            }
+        }');
+        $data = json_decode('{"propertyOne":"ABC"}');
+
+        $v = new Validator();
+        $v->validate($data, $schema, Constraint::CHECK_MODE_EXCEPTIONS);
+        $this->assertTrue($v->isValid());
     }
 }


### PR DESCRIPTION
## What
Don't throw exceptions until evaluation of `anyOf` / `oneOf` has completed.

## Why
This is a bug. Fixes #393.