### PR TITLE
Enable FILTER_FLAG_EMAIL_UNICODE for email format if present

### DIFF
--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -124,7 +124,12 @@ class FormatConstraint extends Constraint
                 break;
 
             case 'email':
-                if (null === filter_var($element, FILTER_VALIDATE_EMAIL, FILTER_NULL_ON_FAILURE)) {
+                $filterFlags = FILTER_NULL_ON_FAILURE;
+                if (defined('FILTER_FLAG_EMAIL_UNICODE')) {
+                    // Only available from PHP >= 7.1.0, so ignore it for coverage checks
+                    $filterFlags |= constant('FILTER_FLAG_EMAIL_UNICODE'); // @codeCoverageIgnore
+                }
+                if (null === filter_var($element, FILTER_VALIDATE_EMAIL, $filterFlags)) {
                     $this->addError(ConstraintError::FORMAT_EMAIL(), $path, array('format' => $schema->format));
                 }
                 break;


### PR DESCRIPTION
## What
If `FILTER_FLAG_EMAIL_UNICODE` is available (PHP >= 7.1.0), enable it for email format checks.

## Why
Because @abhijit-gaonkar asked for it in #397, and because [RFC-5322](https://tools.ietf.org/html/rfc5322#section-3.4.1) does not prohibit unicode characters in email addresses.