### PR TITLE
fix bug when applying defaults

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -253,8 +253,14 @@ class UndefinedConstraint extends Constraint
                 }
             }
         } elseif (isset($schema->items) && LooseTypeCheck::isArray($value)) {
+            $items = array();
+            if (LooseTypeCheck::isArray($schema->items)) {
+                $items = $schema->items;
+            } elseif (isset($schema->minItems) && count($value) < $schema->minItems) {
+                $items = array_fill(count($value), $schema->minItems - count($value), $schema->items);
+            }
             // $value is an array, and items are defined - treat as plain array
-            foreach ($schema->items as $currentItem => $itemDefinition) {
+            foreach ($items as $currentItem => $itemDefinition) {
                 if (
                     !array_key_exists($currentItem, $value)
                     && property_exists($itemDefinition, 'default')

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -149,6 +149,21 @@ class DefaultPropertiesTest extends VeryBaseTestCase
                 '{"items":[{"default":null}]}',
                 '[null]'
             ),
+            array(// #21 items might be a schema (instead of an array of schema)
+                '[{}]',
+                '{"items":{"properties":{"propertyOne":{"default":"valueOne"}}}}',
+                '[{"propertyOne":"valueOne"}]'
+            ),
+            array(// #22 if items is not an array, it does not create a new item
+                '[]',
+                '{"items":{"properties":{"propertyOne":{"default":"valueOne"}}}}',
+                '[]'
+            ),
+            array(// #23 if items is a schema with a default value and minItems is present, fill the array
+                '["a"]',
+                '{"items":{"default":"b"}, "minItems": 3}',
+                '["a","b","b"]'
+            ),
         );
     }
 


### PR DESCRIPTION
> Warning: First parameter must either be an object or the name of an existing class in vendor/justinrainbow/json-schema/src/JsonSchema/Constraints/UndefinedConstraint.php line 261

to reproduce:

```php
<?php

use JsonSchema\Constraints\Constraint;

include_once __DIR__."/../vendor/autoload.php";

$validator = new \JsonSchema\Validator();

$data = [];
$schema = (object)[
    "type" => "array",
    "items" => (object)[
        "required" => [],
        "type" => "object",
    ]
];

$validator->validate($data, $schema, Constraint::CHECK_MODE_APPLY_DEFAULTS);
```

according to the spec:

> The value of "items" MUST be either a schema or array of schemas.

but here the code supposes it's an array of schemas and it fails when it's trying to use `[]` (the value of `required`) as a schema