### PR TITLE
[BUGFIX] Cast empty schema arrays to object

### DIFF
--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -146,7 +146,7 @@ class BaseConstraint
         $json = json_encode($array);
         if (json_last_error() !== \JSON_ERROR_NONE) {
             $message = 'Unable to encode schema array as JSON';
-            if (version_compare(phpversion(), '5.5.0', '>=')) {
+            if (function_exists('json_last_error_msg')) {
                 $message .= ': ' . json_last_error_msg();
             }
             throw new InvalidArgumentException($message);

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -152,6 +152,6 @@ class BaseConstraint
             throw new InvalidArgumentException($message);
         }
 
-        return json_decode($json);
+        return (object) json_decode($json);
     }
 }

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -36,14 +36,15 @@ class SchemaConstraint extends Constraint
             // passed schema
             $validationSchema = $schema;
         } elseif ($this->getTypeCheck()->propertyExists($element, $this->inlineSchemaProperty)) {
-            $inlineSchema = $this->getTypeCheck()->propertyGet($element, $this->inlineSchemaProperty);
-            if (is_array($inlineSchema)) {
-                $inlineSchema = json_decode(json_encode($inlineSchema));
-            }
             // inline schema
-            $validationSchema = $inlineSchema;
+            $validationSchema = $this->getTypeCheck()->propertyGet($element, $this->inlineSchemaProperty);
         } else {
             throw new InvalidArgumentException('no schema found to verify against');
+        }
+
+        // cast array schemas to object
+        if (is_array($validationSchema)) {
+            $validationSchema = BaseConstraint::arrayToObjectRecursive($validationSchema);
         }
 
         // validate schema against whatever is defined in $validationSchema->$schema. If no

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -2,6 +2,7 @@
 
 namespace JsonSchema;
 
+use JsonSchema\Constraints\BaseConstraint;
 use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\UnresolvableJsonPointerException;
 use JsonSchema\Iterator\ObjectIterator;
@@ -51,6 +52,12 @@ class SchemaStorage implements SchemaStorageInterface
             // schemas do not have an associated URI when passed via Validator::validate().
             $schema = $this->uriRetriever->retrieve($id);
         }
+
+        // cast array schemas to object
+        if (is_array($schema)) {
+            $schema = BaseConstraint::arrayToObjectRecursive($schema);
+        }
+
         $objectIterator = new ObjectIterator($schema);
         foreach ($objectIterator as $toResolveSchema) {
             if (property_exists($toResolveSchema, '$ref') && is_string($toResolveSchema->{'$ref'})) {

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -45,11 +45,6 @@ class Validator extends BaseConstraint
         // reset errors prior to validation
         $this->reset();
 
-        // make sure $schema is an object
-        if (is_array($schema)) {
-            $schema = self::arrayToObjectRecursive($schema);
-        }
-
         // set checkMode
         $initialCheckMode = $this->factory->getConfig();
         if ($checkMode !== null) {
@@ -60,7 +55,10 @@ class Validator extends BaseConstraint
         $this->factory->getSchemaStorage()->addSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI, $schema);
 
         $validator = $this->factory->createInstanceFor('schema');
-        $validator->check($value, $schema);
+        $validator->check(
+            $value,
+            $this->factory->getSchemaStorage()->getSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI)
+        );
 
         $this->factory->setConfig($initialCheckMode);
 


### PR DESCRIPTION
## What
 * Cast empty schema arrays to object.
 * Use `function_exists` instead of checking the PHP version.
 * Move array->object casts into `SchemaConstraint` & `SchemaStorage`.

## Why
 * Fixes bugs #407 & #408
 * `function_exists` allows for the use of polyfills, whereas the version check does not.