### PR TITLE
Issue-414: Allow The Option of T or space for Date time.

### DIFF
--- a/src/JsonSchema/Rfc3339.php
+++ b/src/JsonSchema/Rfc3339.php
@@ -4,7 +4,7 @@ namespace JsonSchema;
 
 class Rfc3339
 {
-    const REGEX = '/^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))$/';
+    const REGEX = '/^(\d{4}-\d{2}-\d{2}[T ]{1}\d{2}:\d{2}:\d{2})(\.\d+)?(Z|([+-]\d{2}):?(\d{2}))$/';
 
     /**
      * Try creating a DateTime instance
@@ -22,8 +22,8 @@ class Rfc3339
         $dateAndTime = $matches[1];
         $microseconds = $matches[2] ?: '.000000';
         $timeZone = 'Z' !== $matches[3] ? $matches[4] . ':' . $matches[5] : '+00:00';
-
-        $dateTime = \DateTime::createFromFormat('Y-m-d\TH:i:s.uP', $dateAndTime . $microseconds . $timeZone, new \DateTimeZone('UTC'));
+        $dateFormat = strpos($dateAndTime, 'T') === false ? 'Y-m-d H:i:s.uP' : 'Y-m-d\TH:i:s.uP';
+        $dateTime = \DateTime::createFromFormat($dateFormat, $dateAndTime . $microseconds . $timeZone, new \DateTimeZone('UTC'));
 
         return $dateTime ?: null;
     }

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -35,8 +35,14 @@ class Rfc3339Test extends \PHPUnit_Framework_TestCase
                 '2000-05-01T12:12:12Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s', '2000-05-01T12:12:12', new \DateTimeZone('UTC'))
             ),
-            array('2000-05-01T12:12:12+0100', \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')),
-            array('2000-05-01T12:12:12+01:00', \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')),
+            array(
+                '2000-05-01T12:12:12+0100',
+                \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
+            ),
+            array(
+                '2000-05-01T12:12:12+01:00',
+                \DateTime::createFromFormat('Y-m-d\TH:i:sP', '2000-05-01T12:12:12+01:00')
+            ),
             array(
                 '2000-05-01T12:12:12.123456Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123456', new \DateTimeZone('UTC'))
@@ -45,6 +51,14 @@ class Rfc3339Test extends \PHPUnit_Framework_TestCase
                 '2000-05-01T12:12:12.123Z',
                 \DateTime::createFromFormat('Y-m-d\TH:i:s.u', '2000-05-01T12:12:12.123000', new \DateTimeZone('UTC'))
             ),
+            array(
+                '2000-05-01 12:12:12.123Z',
+                \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123000', new \DateTimeZone('UTC'))
+            ),
+            array(
+                '2000-05-01 12:12:12.123456Z',
+                \DateTime::createFromFormat('Y-m-d H:i:s.u', '2000-05-01 12:12:12.123456', new \DateTimeZone('UTC'))
+            )
         );
     }
 
@@ -54,6 +68,8 @@ class Rfc3339Test extends \PHPUnit_Framework_TestCase
             array('1999-1-11T00:00:00Z'),
             array('1999-01-11T00:00:00+100'),
             array('1999-01-11T00:00:00+1:00'),
+            array('1999-01-01  00:00:00Z'),
+            array('1999-1-11 00:00:00Z')
         );
     }
 }


### PR DESCRIPTION
Please see Github Issue: [#414](https://github.com/justinrainbow/json-schema/issues/414)

This PR is to allow for a `T` or space when providing date times to JSON Schema. 

Let me know if there is anything different you would like me to do or if this is not the direction you would like this project to go in. 

Thank you!