### PR TITLE
[BUGFIX] Split "uri" format into "uri" & "uri-reference", fix meta-schema bug

### DIFF
--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -28,6 +28,7 @@ class ConstraintError extends Enum
     const FORMAT_STYLE = 'styleFormat';
     const FORMAT_TIME = 'timeFormat';
     const FORMAT_URL = 'urlFormat';
+    const FORMAT_URL_REF = 'urlRefFormat';
     const INVALID_SCHEMA = 'invalidSchema';
     const LENGTH_MAX = 'maxLength';
     const LENGTH_MIN = 'minLength';
@@ -77,6 +78,7 @@ class ConstraintError extends Enum
             self::FORMAT_STYLE => 'Invalid style',
             self::FORMAT_TIME => 'Invalid time %s, expected format hh:mm:ss',
             self::FORMAT_URL => 'Invalid URL format',
+            self::FORMAT_URL_REF => 'Invalid URL reference format',
             self::LENGTH_MAX => 'Must be at most %d characters long',
             self::INVALID_SCHEMA => 'Schema is not valid',
             self::LENGTH_MIN => 'Must be at least %d characters long',

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -100,6 +100,13 @@ class FormatConstraint extends Constraint
 
             case 'uri':
                 if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
+                    $this->addError(ConstraintError::FORMAT_URL(), $path, array('format' => $schema->format));
+                }
+                break;
+
+            case 'uriref':
+            case 'uri-reference':
+                if (null === filter_var($element, FILTER_VALIDATE_URL, FILTER_NULL_ON_FAILURE)) {
                     // FILTER_VALIDATE_URL does not conform to RFC-3986, and cannot handle relative URLs, but
                     // the json-schema spec uses RFC-3986, so need a bit of hackery to properly validate them.
                     // See https://tools.ietf.org/html/rfc3986#section-4.2 for additional information.
@@ -118,7 +125,7 @@ class FormatConstraint extends Constraint
                         $validURL = null;
                     }
                     if ($validURL === null) {
-                        $this->addError(ConstraintError::FORMAT_URL(), $path, array('format' => $schema->format));
+                        $this->addError(ConstraintError::FORMAT_URL_REF(), $path, array('format' => $schema->format));
                     }
                 }
                 break;

--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -58,6 +58,17 @@ class SchemaStorage implements SchemaStorageInterface
             $schema = BaseConstraint::arrayToObjectRecursive($schema);
         }
 
+        // workaround for bug in draft-03 & draft-04 meta-schemas (id & $ref defined with incorrect format)
+        // see https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/177#issuecomment-293051367
+        if (is_object($schema) && property_exists($schema, 'id')) {
+            if ($schema->id == 'http://json-schema.org/draft-04/schema#') {
+                $schema->properties->id->format = 'uri-reference';
+            } elseif ($schema->id == 'http://json-schema.org/draft-03/schema#') {
+                $schema->properties->id->format = 'uri-reference';
+                $schema->properties->{'$ref'}->format = 'uri-reference';
+            }
+        }
+
         $objectIterator = new ObjectIterator($schema);
         foreach ($objectIterator as $toResolveSchema) {
             if (property_exists($toResolveSchema, '$ref') && is_string($toResolveSchema->{'$ref'})) {

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -143,12 +143,12 @@ class FormatTest extends BaseTestCase
             array('555 320 1212', 'phone'),
 
             array('http://bluebox.org', 'uri'),
-            array('//bluebox.org', 'uri'),
-            array('/absolutePathReference/', 'uri'),
-            array('./relativePathReference/', 'uri'),
-            array('./relative:PathReference/', 'uri'),
-            array('relativePathReference/', 'uri'),
-            array('relative/Path:Reference/', 'uri'),
+            array('//bluebox.org', 'uri-reference'),
+            array('/absolutePathReference/', 'uri-reference'),
+            array('./relativePathReference/', 'uri-reference'),
+            array('./relative:PathReference/', 'uri-reference'),
+            array('relativePathReference/', 'uri-reference'),
+            array('relative/Path:Reference/', 'uri-reference'),
 
             array('info@something.edu', 'email'),
 
@@ -200,6 +200,12 @@ class FormatTest extends BaseTestCase
             array('htt:/bluebox.org', 'uri'),
             array('.relative:path/reference/', 'uri'),
             array('', 'uri'),
+            array('//bluebox.org', 'uri'),
+            array('/absolutePathReference/', 'uri'),
+            array('./relativePathReference/', 'uri'),
+            array('./relative:PathReference/', 'uri'),
+            array('relativePathReference/', 'uri'),
+            array('relative/Path:Reference/', 'uri'),
 
             array('info@somewhere', 'email'),
 

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -289,4 +289,17 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
         $s->addSchema('http://json-schema.org/draft-04/schema#');
         $this->assertInstanceOf('\JsonSchema\Uri\UriResolver', $s->getUriResolver());
     }
+
+    public function testMetaSchemaFixes()
+    {
+        $s = new SchemaStorage();
+        $s->addSchema('http://json-schema.org/draft-03/schema#');
+        $s->addSchema('http://json-schema.org/draft-04/schema#');
+        $draft_03 = $s->getSchema('http://json-schema.org/draft-03/schema#');
+        $draft_04 = $s->getSchema('http://json-schema.org/draft-04/schema#');
+
+        $this->assertEquals('uri-reference', $draft_03->properties->id->format);
+        $this->assertEquals('uri-reference', $draft_03->properties->{'$ref'}->format);
+        $this->assertEquals('uri-reference', $draft_04->properties->id->format);
+    }
 }


### PR DESCRIPTION
## What
 * Return `"uri"` format to strict validation of only fully-qualified URI.
 * Add `"uri-reference"` format to validate URI references.

## Why
 * [RFC-3986 §1.2.3](https://tools.ietf.org/html/rfc3986#section-1.2.3) says that URI references are not a subset of URI.
 * The draft-03 & draft-04 meta-schemas use the `"uri"` format erroneously - this is a [meta-schema bug](https://github.com/json-schema-org/JSON-Schema-Test-Suite/issues/177#issuecomment-293051367).
 * Fixes #418.