### PR TITLE
[BUGFIX] Tweak phpdocumentor dependency to avoid install conflicts

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.22",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpdocumentor/phpdocumentor": "~2"
+        "phpdocumentor/phpdocumentor": "^2.7"
     },
     "autoload": {
         "psr-4": { "JsonSchema\\": "src/JsonSchema/" }


### PR DESCRIPTION
## What
 * Change `phpdocumentor/phpdocumentor` require-dev dependency from `~2` to `^2.7`.

## Why
 * Resolves a dependency conflict when installing in dev mode (issue #420).