### PR TITLE
[BUGFIX] Add '?' for query string during URI generation

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -61,8 +61,8 @@ class UriResolver implements UriResolverInterface
              . $components['authority']
              . $components['path'];
 
-        if (array_key_exists('query', $components)) {
-            $uri .= $components['query'];
+        if (array_key_exists('query', $components) && strlen($components['query'])) {
+            $uri .= '?' . $components['query'];
         }
         if (array_key_exists('fragment', $components)) {
             $uri .= '#' . $components['fragment'];

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -172,4 +172,22 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testReversable()
+    {
+        $uri = 'scheme://user:password@authority/path?query#fragment';
+        $split = $this->resolver->parse($uri);
+
+        // check that the URI was split as expected
+        $this->assertEquals(array(
+            'scheme' => 'scheme',
+            'authority' => 'user:password@authority',
+            'path' => '/path',
+            'query' => 'query',
+            'fragment' => 'fragment'
+        ), $split);
+
+        // check that the recombined URI matches the original input
+        $this->assertEquals($uri, $this->resolver->generate($split));
+    }
 }


### PR DESCRIPTION
## What
Prefixes non-empty query strings with `?` when building a URI.

## Why
Bugfix for #424 - URI splitting / combining should be a reversable operation.

Note that this bugfix will cause empty query strings to be dropped (e.g. `http://example.com?#blue` becomes `http://example.com#blue`). This is because the `?` character is deliberately not captured as part of the query string, and the testsuite expects to be able to pass an empty query string and *not* have the `?` added for that case.