### PR TITLE
Remove PHPDocumentor & change travis platform for hhvm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - php: 7.1
     - php: 'nightly'
     - php: hhvm
+      dist: trusty
   allow_failures:
     - php: 'nightly'
 

--- a/composer.json
+++ b/composer.json
@@ -41,9 +41,8 @@
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
-        "phpunit/phpunit": "^4.8.22",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpdocumentor/phpdocumentor": "^2.7"
+        "phpunit/phpunit": "^4.8.22"
     },
     "autoload": {
         "psr-4": { "JsonSchema\\": "src/JsonSchema/" }


### PR DESCRIPTION
## What
 * Remove phpdocumentor from dev-time dependencies
 * Change the travis test platform for hhvm to trusty

## Why
 * PHPDocumentor isn't actually called anywhere in our code, and is causing numerous dependency resolution failures. Something upstream has been rather active with causing conflicts lately, and PHPDocumentor development is slow (last release over a year ago) and pulls in a ton of ancient stuff.
 * We should probably replace it with another phpdoc documentation generator at some point - ideally at the same time as we overhaul the documentation in general - but for now, this issue needs a quick fix, and removing the PHPDocumentor requirement feels like the most sensible course of action here.
 * Travis no longer supports HHVM tests on Ubuntu Precise (the current stable test platform), so switching to trusty is required in order to maintain full platform coverage in the testsuite.