### PR TITLE
Backports for 5.2.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
     - php: 7.1
     - php: 'nightly'
     - php: hhvm
+      dist: trusty
   allow_failures:
     - php: 'nightly'
 

--- a/composer.json
+++ b/composer.json
@@ -40,9 +40,8 @@
     },
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
-        "phpunit/phpunit": "^4.8.22",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpdocumentor/phpdocumentor": "^2.7"
+        "phpunit/phpunit": "^4.8.22"
     },
     "autoload": {
         "psr-4": { "JsonSchema\\": "src/JsonSchema/" }

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -61,8 +61,8 @@ class UriResolver implements UriResolverInterface
              . $components['authority']
              . $components['path'];
 
-        if (array_key_exists('query', $components)) {
-            $uri .= $components['query'];
+        if (array_key_exists('query', $components) && strlen($components['query'])) {
+            $uri .= '?' . $components['query'];
         }
         if (array_key_exists('fragment', $components)) {
             $uri .= '#' . $components['fragment'];

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -172,4 +172,22 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
             )
         );
     }
+
+    public function testReversable()
+    {
+        $uri = 'scheme://user:password@authority/path?query#fragment';
+        $split = $this->resolver->parse($uri);
+
+        // check that the URI was split as expected
+        $this->assertEquals(array(
+            'scheme' => 'scheme',
+            'authority' => 'user:password@authority',
+            'path' => '/path',
+            'query' => 'query',
+            'fragment' => 'fragment'
+        ), $split);
+
+        // check that the recombined URI matches the original input
+        $this->assertEquals($uri, $this->resolver->generate($split));
+    }
 }


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.2 without breaking backwards-compatibility. 

## Backported PRs
 * #425 (bugfix for #424 - make uri splitting reversable)
 * #429 (adjust hhvm platform for Travis, remove phpdocumentor dependency)

## Skipped PRs
 There are not currently any skipped PRs.

## Pending PRs
 * #430 (fix error message for draft-03 boolean `required`)