### PR TITLE
Backports for 5.2.2 (Part 2)

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -142,7 +142,13 @@ class UndefinedConstraint extends Constraint
             } elseif (isset($schema->required) && !is_array($schema->required)) {
                 // Draft 3 - Required attribute - e.g. "foo": {"type": "string", "required": true}
                 if ($schema->required && $value instanceof self) {
-                    $this->addError($path, 'Is missing and it is required', 'required');
+                    $propertyPaths = $path->getPropertyPaths();
+                    $propertyName = end($propertyPaths);
+                    $this->addError(
+                        $path,
+                        'The property ' . $propertyName . ' is required',
+                        'required'
+                    );
                 }
             }
         }


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.2 without breaking backwards-compatibility.

See #431 for part 1.

## Backported PRs
 * #432 (fix missing property in boolean required error)

## Skipped PRs
 * #437 (ignore `$ref` siblings & catch infinite-loop references) - bugfix results in a major change to behavior that users may be relying on.