### PR TITLE
[BUGFIX] Ignore $ref siblings & abort on infinite-loop references

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -139,6 +139,7 @@ class SchemaStorage implements SchemaStorageInterface
                 ));
             }
             $resolveStack[] = $refSchema;
+
             return $this->resolveRef($refSchema->{'$ref'}, $resolveStack);
         }
 

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests;
+
+use JsonSchema\Validator;
+
+class RefTest extends \PHPUnit_Framework_TestCase
+{
+    public function dataRefIgnoresSiblings()
+    {
+        return array(
+            // #0 check that $ref is resolved and the instance is validated against
+            // the referenced schema
+            array(
+                '{
+                    "definitions":{"test": {"type": "integer"}},
+                    "properties": {
+                        "propertyOne": {"$ref": "#/definitions/test"}
+                    }
+                }',
+                '{"propertyOne": "not an integer"}',
+                false
+            ),
+            // #1 check that sibling properties of $ref are ignored during validation
+            array(
+                '{
+                    "definitions":{
+                        "test": {"type": "integer"}
+                    },
+                    "properties": {
+                        "propertyOne": {
+                            "$ref": "#/definitions/test",
+                            "maximum": 5
+                        }
+                    }
+                }',
+                '{"propertyOne": 10}',
+                true
+            ),
+        );
+    }
+
+    /** @dataProvider dataRefIgnoresSiblings */
+    public function testRefIgnoresSiblings($schema, $document, $isValid)
+    {
+        $document = json_decode($document);
+        $schema = json_decode($schema);
+
+        $v = new Validator();
+        $v->validate($document, $schema);
+
+        $this->assertEquals($isValid, $v->isValid());
+    }
+}

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -79,7 +79,7 @@ class SchemaStorageTest extends \PHPUnit_Framework_TestCase
         );
 
         // local ref with overriding
-        $this->assertNotEquals(
+        $this->assertEquals(
             $schemaStorage->resolveRef("$mainSchemaPath#/definitions/house/additionalProperties"),
             $schemaStorage->resolveRef("$mainSchemaPath#/properties/house/additionalProperties")
         );


### PR DESCRIPTION
## What
 * Refactor to ignore all other sibling properties where `$ref` is present (fixes #436).
 * Add check for infinitely-looping references

## Why
 * Because the spec states that all sibling properties of `$ref` [MUST be ignored](https://tools.ietf.org/html/draft-wright-json-schema-01#section-8)
 * Because infinitely looping is both undesirable and explicitly prohibited by the spec.

This PR will **not** be backported. #436 is definitely a bug, but fixing it results in a significant change in behavior which some users may be relying on (e.g. as a hack to implement inheritance), and as such it should be merged as major-version change.

Thanks to @johannes-see for finding the bug (#435).