### PR TITLE
Add proper recursive handling for $ref resolution base

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -76,6 +76,17 @@ class UriResolver implements UriResolverInterface
      */
     public function resolve($uri, $baseUri = null)
     {
+        // treat non-uri base as local file path
+        if (!is_null($baseUri) && !filter_var($baseUri, \FILTER_VALIDATE_URL)) {
+            if (is_file($baseUri)) {
+                $baseUri = 'file://' . realpath($baseUri);
+            } elseif (is_dir($baseUri)) {
+                $baseUri = 'file://' . realpath($baseUri) . '/';
+            } else {
+                $baseUri = 'file://' . getcwd() . '/' . $baseUri;
+            }
+        }
+
         if ($uri == '') {
             return $baseUri;
         }

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -52,12 +52,17 @@ class Validator extends BaseConstraint
         }
 
         // add provided schema to SchemaStorage with internal URI to allow internal $ref resolution
-        $this->factory->getSchemaStorage()->addSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI, $schema);
+        if (is_object($schema) && property_exists($schema, 'id')) {
+            $schemaURI = $schema->id;
+        } else {
+            $schemaURI = SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI;
+        }
+        $this->factory->getSchemaStorage()->addSchema($schemaURI, $schema);
 
         $validator = $this->factory->createInstanceFor('schema');
         $validator->check(
             $value,
-            $this->factory->getSchemaStorage()->getSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI)
+            $this->factory->getSchemaStorage()->getSchema($schemaURI)
         );
 
         $this->factory->setConfig($initialCheckMode);

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -190,4 +190,37 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
         // check that the recombined URI matches the original input
         $this->assertEquals($uri, $this->resolver->generate($split));
     }
+
+    public function testRelativeFileAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/src/JsonSchema/Validator.php',
+            $this->resolver->resolve(
+                'Validator.php',
+                'src/JsonSchema/SchemaStorage.php'
+            )
+        );
+    }
+
+    public function testRelativeDirectoryAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/src/JsonSchema/Validator.php',
+            $this->resolver->resolve(
+                'Validator.php',
+                'src/JsonSchema'
+            )
+        );
+    }
+
+    public function testRelativeNonExistentFileAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/resolved.file',
+            $this->resolver->resolve(
+                'resolved.file',
+                'test.file'
+            )
+        );
+    }
 }


### PR DESCRIPTION
# What
Implement recursive resolution of `$ref` base.

# Why
Because the existing code doesn't actually do this properly, and is various combinations of missing and not implemented in this area.

Note that this patch does *not* distinguish between schema and non-schema contexts; it just resolves `$ref` wherever it may occur within a schema. Limiting this to schema-context only may be added later.

`ObjectIterator` is *not* removed, despite now being redundant, as it's a handy class for people who wish to implement their own preprocessor for whatever reason.