### PR TITLE
Update php-csfixer rules to address problem in 2.7 & new multiline rule

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ $config
         '@PSR2' => true,
         '@Symfony' => true,
         // additionally
+        'align_multiline_comment' => array('comment_type' => 'phpdocs_like'),
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
@@ -24,6 +25,7 @@ $config
         'pre_increment' => false,
         'trailing_comma_in_multiline_array' => false,
         'simplified_null_return' => false,
+        'yoda_style' => null,
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -86,8 +86,8 @@ class CollectionConstraint extends Constraint
 
                     $validator->check($v, $schema->items, $k_path, $i);
                 }
-                unset($v); // remove dangling reference to prevent any future bugs
-                           // caused by accidentally using $v elsewhere
+                unset($v); /* remove dangling reference to prevent any future bugs
+                            * caused by accidentally using $v elsewhere */
                 $this->addErrors($typeValidator->getErrors());
                 $this->addErrors($validator->getErrors());
             } else {
@@ -110,8 +110,8 @@ class CollectionConstraint extends Constraint
                         $this->errors = $initErrors;
                     }
                 }
-                unset($v); // remove dangling reference to prevent any future bugs
-                           // caused by accidentally using $v elsewhere
+                unset($v); /* remove dangling reference to prevent any future bugs
+                            * caused by accidentally using $v elsewhere */
             }
         } else {
             // Defined item type definitions
@@ -140,8 +140,8 @@ class CollectionConstraint extends Constraint
                     }
                 }
             }
-            unset($v); // remove dangling reference to prevent any future bugs
-                       // caused by accidentally using $v elsewhere
+            unset($v); /* remove dangling reference to prevent any future bugs
+                        * caused by accidentally using $v elsewhere */
 
             // Treat when we have more schema definitions than values, not for empty arrays
             if (count($value) > 0) {


### PR DESCRIPTION
## What
 * Configure to ignore processing of `yoda_style` rules
 * Explicitly set multiline comment mode
 * Update comment syntax for multiline `//` prefix
 * Explicitly run PHP-5.3 Travis tests on `precise`

## Why
 * `yoda_style` in 2.7 is dangerous and may result in logic errors. In some cases, it also results in invalid syntax.

 * multiline comments prefixed with `//` now seem to be misaligned, and this cannot be disabled, so have changed the relevant comment.

 * `trusty` is now the default PHP testing distro on Travis, and it does not support PHP-5.3.