### PR TITLE
Backports for 5.2.2 (Part 3)

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,6 +11,7 @@ $config
         '@PSR2' => true,
         '@Symfony' => true,
         // additionally
+        'align_multiline_comment' => array('comment_type' => 'phpdocs_like'),
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
@@ -24,6 +25,7 @@ $config
         'pre_increment' => false,
         'trailing_comma_in_multiline_array' => false,
         'simplified_null_return' => false,
+        'yoda_style' => null,
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
   fast_finish: true
   include:
     - php: 5.3
+      dist: precise
     - php: 5.4
     - php: 5.5
     - php: 5.6

--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -85,8 +85,8 @@ class CollectionConstraint extends Constraint
 
                     $validator->check($v, $schema->items, $k_path, $i);
                 }
-                unset($v); // remove dangling reference to prevent any future bugs
-                           // caused by accidentally using $v elsewhere
+                unset($v); /* remove dangling reference to prevent any future bugs
+                            * caused by accidentally using $v elsewhere */
                 $this->addErrors($typeValidator->getErrors());
                 $this->addErrors($validator->getErrors());
             } else {
@@ -109,8 +109,8 @@ class CollectionConstraint extends Constraint
                         $this->errors = $initErrors;
                     }
                 }
-                unset($v); // remove dangling reference to prevent any future bugs
-                           // caused by accidentally using $v elsewhere
+                unset($v); /* remove dangling reference to prevent any future bugs
+                            * caused by accidentally using $v elsewhere */
             }
         } else {
             // Defined item type definitions
@@ -132,8 +132,8 @@ class CollectionConstraint extends Constraint
                     }
                 }
             }
-            unset($v); // remove dangling reference to prevent any future bugs
-                       // caused by accidentally using $v elsewhere
+            unset($v); /* remove dangling reference to prevent any future bugs
+                        * caused by accidentally using $v elsewhere */
 
             // Treat when we have more schema definitions than values, not for empty arrays
             if (count($value) > 0) {

--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -76,6 +76,17 @@ class UriResolver implements UriResolverInterface
      */
     public function resolve($uri, $baseUri = null)
     {
+        // treat non-uri base as local file path
+        if (!is_null($baseUri) && !filter_var($baseUri, \FILTER_VALIDATE_URL)) {
+            if (is_file($baseUri)) {
+                $baseUri = 'file://' . realpath($baseUri);
+            } elseif (is_dir($baseUri)) {
+                $baseUri = 'file://' . realpath($baseUri) . '/';
+            } else {
+                $baseUri = 'file://' . getcwd() . '/' . $baseUri;
+            }
+        }
+
         if ($uri == '') {
             return $baseUri;
         }

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -54,12 +54,17 @@ class Validator extends BaseConstraint
         }
 
         // add provided schema to SchemaStorage with internal URI to allow internal $ref resolution
-        $this->factory->getSchemaStorage()->addSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI, $schema);
+        if (is_object($schema) && property_exists($schema, 'id')) {
+            $schemaURI = $schema->id;
+        } else {
+            $schemaURI = SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI;
+        }
+        $this->factory->getSchemaStorage()->addSchema($schemaURI, $schema);
 
         $validator = $this->factory->createInstanceFor('schema');
         $validator->check(
             $value,
-            $this->factory->getSchemaStorage()->getSchema(SchemaStorage::INTERNAL_PROVIDED_SCHEMA_URI)
+            $this->factory->getSchemaStorage()->getSchema($schemaURI)
         );
 
         $this->factory->setConfig($initialCheckMode);

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -190,4 +190,37 @@ class UriResolverTest extends \PHPUnit_Framework_TestCase
         // check that the recombined URI matches the original input
         $this->assertEquals($uri, $this->resolver->generate($split));
     }
+
+    public function testRelativeFileAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/src/JsonSchema/Validator.php',
+            $this->resolver->resolve(
+                'Validator.php',
+                'src/JsonSchema/SchemaStorage.php'
+            )
+        );
+    }
+
+    public function testRelativeDirectoryAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/src/JsonSchema/Validator.php',
+            $this->resolver->resolve(
+                'Validator.php',
+                'src/JsonSchema'
+            )
+        );
+    }
+
+    public function testRelativeNonExistentFileAsRoot()
+    {
+        $this->assertEquals(
+            'file://' . getcwd() . '/resolved.file',
+            $this->resolver->resolve(
+                'resolved.file',
+                'test.file'
+            )
+        );
+    }
 }


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.2 without breaking backwards-compatibility.

See #431 for part 1 and #433 for part 2.

## Backported PRs
 * #449 (Update config for php-cs-fixer & travis)
 * #448 (add proper recursive handling for `$ref` - fixes #447)

## Skipped PRs
None.