### PR TITLE
[BUGFIX] Don't resolve a schema id against itself

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -92,7 +92,7 @@ class SchemaStorage implements SchemaStorageInterface
             return;
         }
 
-        if (property_exists($schema, 'id') && is_string($schema->id)) {
+        if (property_exists($schema, 'id') && is_string($schema->id) && $base != $schema->id) {
             $base = $this->uriResolver->resolve($schema->id, $base);
         }
 


### PR DESCRIPTION
## What
Add a missing condition to prevent resolving a schema id against itself. This prevents potential double-resolution of relative paths.

## Why
Because this is a bug, and double-resolution of relative paths results in an incorrect dereferencing result.