### PR TITLE
Backports for 5.2.3

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -92,7 +92,7 @@ class SchemaStorage implements SchemaStorageInterface
             return;
         }
 
-        if (property_exists($schema, 'id') && is_string($schema->id)) {
+        if (property_exists($schema, 'id') && is_string($schema->id) && $base != $schema->id) {
             $base = $this->uriResolver->resolve($schema->id, $base);
         }
 


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.3 without breaking backwards-compatibility.

## Backported PRs
 * #452 (bugfix for id double-resolution introduced in 5.2.2)

## Skipped PRs
There are no skipped PRs.