### PR TITLE
Don't add a `file://` prefix to URI that already have a scheme

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -77,7 +77,11 @@ class UriResolver implements UriResolverInterface
     public function resolve($uri, $baseUri = null)
     {
         // treat non-uri base as local file path
-        if (!is_null($baseUri) && !filter_var($baseUri, \FILTER_VALIDATE_URL)) {
+        if (
+            !is_null($baseUri) &&
+            !filter_var($baseUri, \FILTER_VALIDATE_URL) &&
+            !preg_match('|^[^/]+://|u', $baseUri)
+        ) {
             if (is_file($baseUri)) {
                 $baseUri = 'file://' . realpath($baseUri);
             } elseif (is_dir($baseUri)) {


### PR DESCRIPTION
## What
Add regex filter to URI check when expanding `$ref`.

## Why
Some URI types do not pass validation against `\FILTER_VAR_URL` (e.g. `phar://`), but are still valid and still have a scheme. This patch catches those situations via a simple regex.

Fixes #451.