### PR TITLE
Backports for 5.2.5

### DIFF
--- a/src/JsonSchema/Uri/UriResolver.php
+++ b/src/JsonSchema/Uri/UriResolver.php
@@ -77,7 +77,11 @@ class UriResolver implements UriResolverInterface
     public function resolve($uri, $baseUri = null)
     {
         // treat non-uri base as local file path
-        if (!is_null($baseUri) && !filter_var($baseUri, \FILTER_VALIDATE_URL)) {
+        if (
+            !is_null($baseUri) &&
+            !filter_var($baseUri, \FILTER_VALIDATE_URL) &&
+            !preg_match('|^[^/]+://|u', $baseUri)
+        ) {
             if (is_file($baseUri)) {
                 $baseUri = 'file://' . realpath($baseUri);
             } elseif (is_dir($baseUri)) {


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.5 without breaking backwards-compatibility.

## Backported PRs
 * #452 (Don't add a `file://` prefix to URI that already have a scheme)

## Skipped PRs
There are no skipped PRs.