### PR TITLE
Add a path to the default internal URI

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -10,7 +10,7 @@ use JsonSchema\Uri\UriRetriever;
 
 class SchemaStorage implements SchemaStorageInterface
 {
-    const INTERNAL_PROVIDED_SCHEMA_URI = 'internal://provided-schema';
+    const INTERNAL_PROVIDED_SCHEMA_URI = 'internal://provided-schema/';
 
     protected $uriRetriever;
     protected $uriResolver;


### PR DESCRIPTION
## What
Add a path element to the internal default schema URI

## Why
Because `UriResolver::resolve()` cannot resolve a relative path against a pathless base.

Fixes #458.