### PR TITLE
Backports for 5.2.6

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -10,7 +10,7 @@ use JsonSchema\Uri\UriRetriever;
 
 class SchemaStorage implements SchemaStorageInterface
 {
-    const INTERNAL_PROVIDED_SCHEMA_URI = 'internal://provided-schema';
+    const INTERNAL_PROVIDED_SCHEMA_URI = 'internal://provided-schema/';
 
     protected $uriRetriever;
     protected $uriResolver;


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/6.0.0-dev) that can be backported to 5.2.6 without breaking backwards-compatibility.

## Backported PRs
 * #459 (Add a path to the default internal URI - fixes #458)

## Skipped PRs
There are no skipped PRs.