### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpunit/phpunit": "^4.8.22"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-4": { "JsonSchema\\": "src/JsonSchema/" }

--- a/tests/ConstraintErrorTest.php
+++ b/tests/ConstraintErrorTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests;
 
 use JsonSchema\ConstraintError;
+use PHPUnit\Framework\TestCase;
 
-class ConstraintErrorTest extends \PHPUnit_Framework_TestCase
+class ConstraintErrorTest extends TestCase
 {
     public function testGetValidMessage()
     {

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -12,7 +12,7 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\Entity\JsonPointer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MyBadConstraint

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class PointerTest extends \PHPUnit_Framework_TestCase
+class PointerTest extends TestCase
 {
     protected $validateSchema = true;
 

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -11,8 +11,9 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class SchemaValidationTest extends \PHPUnit_Framework_TestCase
+class SchemaValidationTest extends TestCase
 {
     protected $validateSchema = true;
 

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Constraints\TypeConstraint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TypeTest
@@ -19,7 +20,7 @@ use JsonSchema\Constraints\TypeConstraint;
  *
  * @author hakre <https://github.com/hakre>
  */
-class TypeTest extends \PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
     /**
      * @see testIndefiniteArticleForTypeInTypeCheckErrorMessage

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -12,8 +12,9 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\ValidationException;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class ValidationExceptionTest extends TestCase
 {
     public function testValidationException()
     {

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -9,12 +9,13 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
  * @package JsonSchema\Tests\Constraints
  */
-abstract class VeryBaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class VeryBaseTestCase extends TestCase
 {
     /** @var object */
     private $jsonSchemaDraft03;

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -10,13 +10,14 @@
 namespace JsonSchema\Tests\Entity;
 
 use JsonSchema\Entity\JsonPointer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @package JsonSchema\Tests\Entity
  *
  * @author Joost Nijhuis <jnijhuis81@gmail.com>
  */
-class JsonPointerTest extends \PHPUnit_Framework_TestCase
+class JsonPointerTest extends TestCase
 {
     /**
      * @dataProvider getTestData

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
+++ b/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidSchemaMediaTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidSchemaMediaTypeExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/InvalidSourceUriExceptionTest.php
+++ b/tests/Exception/InvalidSourceUriExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSourceUriException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidSourceUriExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidSourceUriExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/JsonDecodingExceptionTest.php
+++ b/tests/Exception/JsonDecodingExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\JsonDecodingException;
+use PHPUnit\Framework\TestCase;
 
-class JsonDecodingExceptionTest extends \PHPUnit_Framework_TestCase
+class JsonDecodingExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/ResourceNotFoundExceptionTest.php
+++ b/tests/Exception/ResourceNotFoundExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\ResourceNotFoundException;
+use PHPUnit\Framework\TestCase;
 
-class ResourceNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ResourceNotFoundExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\RuntimeException;
+use PHPUnit\Framework\TestCase;
 
-class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
+class RuntimeExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/UnresolvableJsonPointerExceptionTest.php
+++ b/tests/Exception/UnresolvableJsonPointerExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UnresolvableJsonPointerException;
+use PHPUnit\Framework\TestCase;
 
-class UnresolvableJsonPointerExceptionTest extends \PHPUnit_Framework_TestCase
+class UnresolvableJsonPointerExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/UriResolverExceptionTest.php
+++ b/tests/Exception/UriResolverExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UriResolverException;
+use PHPUnit\Framework\TestCase;
 
-class UriResolverExceptionTest extends \PHPUnit_Framework_TestCase
+class UriResolverExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests\Iterators;
 
 use JsonSchema\Iterator\ObjectIterator;
+use PHPUnit\Framework\TestCase;
 
-class ObjectIteratorTest extends \PHPUnit_Framework_TestCase
+class ObjectIteratorTest extends TestCase
 {
     protected $testObject;
 

--- a/tests/RefTest.php
+++ b/tests/RefTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests;
 
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class RefTest extends \PHPUnit_Framework_TestCase
+class RefTest extends TestCase
 {
     public function dataRefIgnoresSiblings()
     {

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests;
 
 use JsonSchema\Rfc3339;
+use PHPUnit\Framework\TestCase;
 
-class Rfc3339Test extends \PHPUnit_Framework_TestCase
+class Rfc3339Test extends TestCase
 {
     /**
      * @param string         $string

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -12,9 +12,10 @@ namespace JsonSchema\Tests;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class SchemaStorageTest extends \PHPUnit_Framework_TestCase
+class SchemaStorageTest extends TestCase
 {
     public function testResolveRef()
     {

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Uri\Retrievers
 {
     use JsonSchema\Uri\Retrievers\Curl;
+    use PHPUnit\Framework\TestCase;
 
-    class CurlTest extends \PHPUnit_Framework_TestCase
+    class CurlTest extends TestCase
     {
         public function testRetrieveFile()
         {

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -3,11 +3,12 @@
 namespace JsonSchema\Tests\Uri\Retrievers
 {
     use JsonSchema\Uri\Retrievers\FileGetContents;
+    use PHPUnit\Framework\TestCase;
 
     /**
      * @group FileGetContents
      */
-    class FileGetContentsTest extends \PHPUnit_Framework_TestCase
+    class FileGetContentsTest extends TestCase
     {
         /**
          * @expectedException \JsonSchema\Exception\ResourceNotFoundException

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -3,11 +3,12 @@
 namespace JsonSchema\Tests\Uri\Retrievers;
 
 use JsonSchema\Uri\Retrievers\PredefinedArray;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group PredefinedArray
  */
-class PredefinedArrayTest extends \PHPUnit_Framework_TestCase
+class PredefinedArrayTest extends TestCase
 {
     private $retriever;
 

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Uri\UriResolver;
+use PHPUnit\Framework\TestCase;
 
-class UriResolverTest extends \PHPUnit_Framework_TestCase
+class UriResolverTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -12,11 +12,12 @@ namespace JsonSchema\Tests\Uri;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group UriRetriever
  */
-class UriRetrieverTest extends \PHPUnit_Framework_TestCase
+class UriRetrieverTest extends TestCase
 {
     protected $validator;
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -4,8 +4,9 @@ namespace JsonSchema\Tests;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function testValidateWithAssocSchema()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.