### PR TITLE
Fix: Mark check() and coerce() as deprecated

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -217,7 +217,7 @@ if (isset($arOptions['--dump-schema'])) {
 
 try {
     $validator = new JsonSchema\Validator();
-    $validator->check($data, $schema);
+    $validator->validate($data, $schema);
 
     if ($validator->isValid()) {
         if(isset($arOptions['--verbose'])) {

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -6,7 +6,7 @@ $data = json_decode(file_get_contents('data.json'));
 
 // Validate
 $validator = new JsonSchema\Validator();
-$validator->check($data, (object) array('$ref' => 'file://' . realpath('schema.json')));
+$validator->validate($data, (object) array('$ref' => 'file://' . realpath('schema.json')));
 
 if ($validator->isValid()) {
     echo "The supplied JSON validates against the schema.\n";

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -74,6 +74,8 @@ class Validator extends BaseConstraint
 
     /**
      * Alias to validate(), to maintain backwards-compatibility with the previous API
+     *
+     * @deprecated
      */
     public function check($value, $schema)
     {
@@ -82,6 +84,8 @@ class Validator extends BaseConstraint
 
     /**
      * Alias to validate(), to maintain backwards-compatibility with the previous API
+     *
+     * @deprecated
      */
     public function coerce(&$value, $schema)
     {

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -41,7 +41,7 @@ class LongArraysTest extends VeryBaseTestCase
 
         $validator = new Validator(new Factory($schemaStorage));
         $checkValue = json_decode($input);
-        $validator->check($checkValue, $schema);
+        $validator->validate($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 
@@ -69,7 +69,7 @@ class LongArraysTest extends VeryBaseTestCase
 
         $validator = new Validator(new Factory($schemaStorage));
         $checkValue = json_decode($input);
-        $validator->check($checkValue, $schema);
+        $validator->validate($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 
@@ -97,7 +97,7 @@ class LongArraysTest extends VeryBaseTestCase
 
         $validator = new Validator(new Factory($schemaStorage));
         $checkValue = json_decode($input);
-        $validator->check($checkValue, $schema);
+        $validator->validate($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
 

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -83,7 +83,7 @@ class PointerTest extends TestCase
 
         $validator = new Validator();
         $checkValue = json_decode(json_encode($value));
-        $validator->check($checkValue, json_decode(json_encode($schema)));
+        $validator->validate($checkValue, json_decode(json_encode($schema)));
 
         $this->assertEquals(
             array(

--- a/tests/Constraints/SelfDefinedSchemaTest.php
+++ b/tests/Constraints/SelfDefinedSchemaTest.php
@@ -69,8 +69,13 @@ class SelfDefinedSchemaTest extends BaseTestCase
 
     public function testInvalidArgumentException()
     {
+        $value = json_decode('{}');
+        $schema = json_decode('');
+
         $v = new Validator();
+
         $this->setExpectedException('\JsonSchema\Exception\InvalidArgumentException');
-        $v->check(json_decode('{}'), json_decode(''));
+
+        $v->validate($value, $schema);
     }
 }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -55,7 +55,7 @@ class UriRetrieverTest extends TestCase
         $decodedJson = json_decode($json);
         $decodedJsonSchema = json_decode($childSchema);
 
-        $this->validator->check($decodedJson, $decodedJsonSchema);
+        $this->validator->validate($decodedJson, $decodedJsonSchema);
         $this->assertTrue($this->validator->isValid());
     }
 
@@ -70,7 +70,7 @@ class UriRetrieverTest extends TestCase
         $decodedJson = json_decode($json);
         $decodedJsonSchema = json_decode($childSchema);
 
-        $this->validator->check($decodedJson, $decodedJsonSchema);
+        $this->validator->validate($decodedJson, $decodedJsonSchema);
         $this->assertFalse($this->validator->isValid());
     }
 
@@ -85,7 +85,7 @@ class UriRetrieverTest extends TestCase
         $decodedJson = json_decode($json);
         $decodedJsonSchema = json_decode($childSchema);
 
-        $this->validator->check($decodedJson, $decodedJsonSchema);
+        $this->validator->validate($decodedJson, $decodedJsonSchema);
         $this->assertFalse($this->validator->isValid());
     }
 
@@ -101,7 +101,7 @@ class UriRetrieverTest extends TestCase
         $decodedJson = json_decode($json);
         $decodedJsonSchema = json_decode($childSchema);
 
-        $this->validator->check($decodedJson, $decodedJsonSchema);
+        $this->validator->validate($decodedJson, $decodedJsonSchema);
         $this->assertTrue($this->validator->isValid());
     }
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -36,7 +36,7 @@ class ValidatorTest extends TestCase
         $validator->validate($data, $schema);
     }
 
-    public function testCheck()
+    public function testDeprecatedCheckDelegatesToValidate()
     {
         $schema = json_decode('{"type":"string"}');
         $data = json_decode('42');
@@ -47,7 +47,7 @@ class ValidatorTest extends TestCase
         $this->assertFalse($validator->isValid(), 'Validation succeeded, but should have failed.');
     }
 
-    public function testCoerce()
+    public function testDeprecatedCoerceDelegatesToValidate()
     {
         $schema = json_decode('{"type":"integer"}');
         $data = json_decode('"42"');


### PR DESCRIPTION
This PR

* [x] marks `Validator::check()` and `Validator::coerce()` as deprecated