### PR TITLE
Fix: No need to specify path to bin directory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,10 +57,10 @@
         }
     },
     "scripts": {
-        "test" : "vendor/bin/phpunit",
-        "testOnly" : "vendor/bin/phpunit --colors --filter",
-        "coverage" : "vendor/bin/phpunit --coverage-text",
-        "style-check" : "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix" : "vendor/bin/php-cs-fixer fix --verbose"
+        "test" : "phpunit",
+        "testOnly" : "phpunit --colors --filter",
+        "coverage" : "phpunit --coverage-text",
+        "style-check" : "php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix" : "php-cs-fixer fix --verbose"
     }
 }


### PR DESCRIPTION
This PR

* [x] removes `vendor/bin` from scripts defined in `composer.json`

💁‍♂️ For reference, see https://getcomposer.org/doc/articles/scripts.md#writing-custom-commands:

>Note: Before executing scripts, Composer's bin-dir is temporarily pushed on top of the PATH environment variable so that binaries of dependencies are easily accessible. In this example no matter if the `phpunit` binary is actually in `vendor/bin/phpunit` or `bin/phpunit` it will be found and executed.