### PR TITLE
Fix: No need to update composer itself

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
-  - composer selfupdate
   - if [[ "$TRAVIS_PHP_VERSION" = "hhvm" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:


### PR DESCRIPTION
This PR

* [x] removes a run of `composer self-update` from the `before_install` section

💁‍♂️ That's already happing implicitly on Travis, no need to do it twice. See for example https://travis-ci.org/justinrainbow/json-schema/jobs/301016931#L476-L479.