### PR TITLE
Fix: Add PHP 7.2 to build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - php: 7.0
       env: WITH_COVERAGE=true WITH_PHPCSFIXER=true
     - php: 7.1
+    - php: 7.2
     - php: 'nightly'
     - php: hhvm
       dist: trusty


### PR DESCRIPTION
This PR

* [x] adds PHP 7.2 to the Travis build matrix