### PR TITLE
Fix: Consistently indent with 2 spaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: php
 
 cache:
-    directories:
-      - $HOME/.composer/cache
-      - $HOME/.phpcsfixer
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.phpcsfixer
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
This PR

* [x] consistently indents `.travis.yml` with 2 spaces

Related to #482.