### PR TITLE
Fix: Remove rule for ignoring bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 /vendor
-/bin
-!/bin/validate-json
 coverage
 .buildpath
 .project


### PR DESCRIPTION
This PR

* [x] removes a rule for ignoring the `bin` directory