### PR TITLE
Fix: Remove unused argument from method call

### DIFF
--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -114,7 +114,7 @@ class SchemaStorageTest extends TestCase
         $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
         $uriRetriever->retrieve($mainSchemaPath)
             ->willReturn($mainSchema)
-            ->shouldBeCalled($mainSchema);
+            ->shouldBeCalled();
 
         $schemaStorage = new SchemaStorage($uriRetriever->reveal());
         $schemaStorage->resolveRef("$mainSchemaPath#/definitions/car");


### PR DESCRIPTION
This PR

* [x] removes an unused argument from a method call