### PR TITLE
Fix: Keep rules sorted in .php_cs.dist

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,6 +15,7 @@ $config
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
+        'increment_style' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,
@@ -22,10 +23,9 @@ $config
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
         'pre_increment' => false,
-        'trailing_comma_in_multiline_array' => false,
         'simplified_null_return' => false,
+        'trailing_comma_in_multiline_array' => false,
         'yoda_style' => null,
-        'increment_style' => false,
     ))
     ->setFinder($finder)
 ;


### PR DESCRIPTION
This PR

* [x] keeps rules in `.php_cs.dist` sorted

💁‍♂️ This ideally makes it more obvious where to add new rules (in order).