### PR TITLE
 Enhancement: Enable no_alias_function and trailing_comma_in_multiline_array fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -29,6 +29,7 @@ $config
         'phpdoc_types_order' => array('null_adjustment' => 'none', 'sort_algorithm' => 'none'),
     ))
     ->setFinder($finder)
+    ->setRiskyAllowed(true)
 ;
 
 return $config;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ $config
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
+        'no_alias_functions' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,

--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -134,10 +134,10 @@ class TypeConstraint extends Constraint
             return implode($delimiter, $elements);
         }
         $lastElement  = array_slice($elements, -1);
-        $firsElements = join($delimiter, array_slice($elements, 0, -1));
+        $firsElements = implode($delimiter, array_slice($elements, 0, -1));
         $implodedElements = array_merge(array($firsElements), $lastElement);
 
-        return join(" $listEnd ", $implodedElements);
+        return implode(" $listEnd ", $implodedElements);
     }
 
     /**


### PR DESCRIPTION
This PR

* [x] enables the `no_alias_function` as well as the `trailing_comma_in_multiline_array` fixer
* [x] runs `composer style-fix`

💁‍♂️ For reference, see https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/2.9#usage:

> **no_alias_functions** [`@Symfony:risky`]
>
>Master functions shall be used instead of aliases.
>
>Risky rule: risky when any of the alias functions are overridden.