### PR TITLE
[BUGFIX] Apply defaults in $ref'ed property / item definitions

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -265,6 +265,7 @@ class UndefinedConstraint extends Constraint
             }
             // $value is an array, and items are defined - treat as plain array
             foreach ($items as $currentItem => $itemDefinition) {
+                $itemDefinition = $this->factory->getSchemaStorage()->resolveRefSchema($itemDefinition);
                 if (
                     !array_key_exists($currentItem, $value)
                     && property_exists($itemDefinition, 'default')

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -241,6 +241,7 @@ class UndefinedConstraint extends Constraint
         if (isset($schema->properties) && LooseTypeCheck::isObject($value)) {
             // $value is an object or assoc array, and properties are defined - treat as an object
             foreach ($schema->properties as $currentProperty => $propertyDefinition) {
+                $propertyDefinition = $this->factory->getSchemaStorage()->resolveRefSchema($propertyDefinition);
                 if (
                     !LooseTypeCheck::propertyExists($value, $currentProperty)
                     && property_exists($propertyDefinition, 'default')

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -126,7 +126,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
             ),
             array(// #16 infinite recursion via $ref (array)
                 '[]',
-                '{"items":[{"$ref":"#","default":[]}]}',
+                '{"items":[{"$ref":"#","default":"valueOne"}], "default": []}',
                 '[[]]'
             ),
             array(// #17 default top value does not overwrite defined null

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -121,7 +121,7 @@ class DefaultPropertiesTest extends VeryBaseTestCase
             ),
             array(// #15 infinite recursion via $ref (object)
                 '{}',
-                '{"properties":{"propertyOne": {"$ref": "#","default": {}}}}',
+                '{"properties":{"propertyOne": {"$ref": "#","default": "valueOne"}}, "default": {}}',
                 '{"propertyOne":{}}'
             ),
             array(// #16 infinite recursion via $ref (array)


### PR DESCRIPTION
## What
Dereference property and array item definitions prior to checking for a default value. Fixes #473.

## Why
Because the spec says:
 1. We should be ignoring siblings of `$ref` (so `default` isn't valid here anyway); and
 2. There might be a `default` defined in the reference target.