### PR TITLE
Backports for 5.2.7

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,7 +1,7 @@
 <?php
 
 $finder = new PhpCsFixer\Finder();
-$config = new PhpCsFixer\Config('json-schema', 'json-schema style guide');
+$config = new PhpCsFixer\Config('json-schema');
 $finder->in(__DIR__);
 
 /* Based on ^2.1 of php-cs-fixer */

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -26,6 +26,7 @@ $config
         'trailing_comma_in_multiline_array' => false,
         'simplified_null_return' => false,
         'yoda_style' => null,
+        'increment_style' => false,
     ))
     ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,6 +15,7 @@ $config
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
+        'increment_style' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,
@@ -22,10 +23,9 @@ $config
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
         'pre_increment' => false,
-        'trailing_comma_in_multiline_array' => false,
         'simplified_null_return' => false,
+        'trailing_comma_in_multiline_array' => false,
         'yoda_style' => null,
-        'increment_style' => false,
     ))
     ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -15,7 +15,6 @@ $config
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
-        'no_unused_imports' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,9 @@ sudo: false
 language: php
 
 cache:
-    directories:
-      - $HOME/.composer/cache
-      - $HOME/.phpcsfixer
+  directories:
+    - $HOME/.composer/cache
+    - $HOME/.phpcsfixer
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ matrix:
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
-  - composer selfupdate
   - if [[ "$TRAVIS_PHP_VERSION" = "hhvm" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ matrix:
     - php: 7.0
       env: WITH_COVERAGE=true WITH_PHPCSFIXER=true
     - php: 7.1
+    - php: 7.2
     - php: 'nightly'
     - php: hhvm
       dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,7 @@
     "require-dev": {
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "friendsofphp/php-cs-fixer": "^2.1",
-        "phpunit/phpunit": "^4.8.22"
+        "phpunit/phpunit": "^4.8.35"
     },
     "autoload": {
         "psr-4": { "JsonSchema\\": "src/JsonSchema/" }

--- a/composer.json
+++ b/composer.json
@@ -56,10 +56,10 @@
         }
     },
     "scripts": {
-        "test" : "vendor/bin/phpunit",
-        "testOnly" : "vendor/bin/phpunit --colors --filter",
-        "coverage" : "vendor/bin/phpunit --coverage-text",
-        "style-check" : "vendor/bin/php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix" : "vendor/bin/php-cs-fixer fix --verbose"
+        "test" : "phpunit",
+        "testOnly" : "phpunit --colors --filter",
+        "coverage" : "phpunit --coverage-text",
+        "style-check" : "php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix" : "php-cs-fixer fix --verbose"
     }
 }

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -10,9 +10,6 @@
 namespace JsonSchema\Constraints;
 
 use JsonSchema\Entity\JsonPointer;
-use JsonSchema\SchemaStorage;
-use JsonSchema\Uri\UriRetriever;
-use JsonSchema\UriRetrieverInterface;
 
 /**
  * The Base Constraints, all Validators should extend this class

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -9,9 +9,7 @@
 
 namespace JsonSchema\Constraints;
 
-use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\InvalidArgumentException;
-use JsonSchema\Exception\InvalidConfigException;
 use JsonSchema\SchemaStorage;
 use JsonSchema\SchemaStorageInterface;
 use JsonSchema\Uri\UriRetriever;

--- a/src/JsonSchema/Constraints/SchemaConstraint.php
+++ b/src/JsonSchema/Constraints/SchemaConstraint.php
@@ -13,7 +13,6 @@ use JsonSchema\Entity\JsonPointer;
 use JsonSchema\Exception\InvalidArgumentException;
 use JsonSchema\Exception\InvalidSchemaException;
 use JsonSchema\Exception\RuntimeException;
-use JsonSchema\SchemaStorage;
 use JsonSchema\Validator;
 
 /**

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -243,6 +243,7 @@ class UndefinedConstraint extends Constraint
         if (isset($schema->properties) && LooseTypeCheck::isObject($value)) {
             // $value is an object or assoc array, and properties are defined - treat as an object
             foreach ($schema->properties as $currentProperty => $propertyDefinition) {
+                $propertyDefinition = $this->factory->getSchemaStorage()->resolveRefSchema($propertyDefinition);
                 if (
                     !LooseTypeCheck::propertyExists($value, $currentProperty)
                     && property_exists($propertyDefinition, 'default')
@@ -266,6 +267,7 @@ class UndefinedConstraint extends Constraint
             }
             // $value is an array, and items are defined - treat as plain array
             foreach ($items as $currentItem => $itemDefinition) {
+                $itemDefinition = $this->factory->getSchemaStorage()->resolveRefSchema($itemDefinition);
                 if (
                     !array_key_exists($currentItem, $value)
                     && property_exists($itemDefinition, 'default')

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -11,8 +11,6 @@ namespace JsonSchema;
 
 use JsonSchema\Constraints\BaseConstraint;
 use JsonSchema\Constraints\Constraint;
-use JsonSchema\Exception\InvalidConfigException;
-use JsonSchema\SchemaStorage;
 
 /**
  * A JsonSchema Constraint

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -12,7 +12,6 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\SchemaStorage;
-use JsonSchema\Uri\UriResolver;
 use JsonSchema\Validator;
 
 class CoerciveTest extends BasicTypesTest

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -121,12 +121,12 @@ class DefaultPropertiesTest extends VeryBaseTestCase
             ),
             array(// #15 infinite recursion via $ref (object)
                 '{}',
-                '{"properties":{"propertyOne": {"$ref": "#","default": {}}}}',
+                '{"properties":{"propertyOne": {"$ref": "#","default": "valueOne"}}, "default": {}}',
                 '{"propertyOne":{}}'
             ),
             array(// #16 infinite recursion via $ref (array)
                 '[]',
-                '{"items":[{"$ref":"#","default":[]}]}',
+                '{"items":[{"$ref":"#","default":"valueOne"}], "default": []}',
                 '[[]]'
             ),
             array(// #17 default top value does not overwrite defined null

--- a/tests/Constraints/DefaultPropertiesTest.php
+++ b/tests/Constraints/DefaultPropertiesTest.php
@@ -121,12 +121,12 @@ class DefaultPropertiesTest extends VeryBaseTestCase
             ),
             array(// #15 infinite recursion via $ref (object)
                 '{}',
-                '{"properties":{"propertyOne": {"$ref": "#","default": "valueOne"}}, "default": {}}',
+                '{"properties":{"propertyOne": {"$ref": "#","default": {}}}, "default": "valueOne"}',
                 '{"propertyOne":{}}'
             ),
             array(// #16 infinite recursion via $ref (array)
                 '[]',
-                '{"items":[{"$ref":"#","default":"valueOne"}], "default": []}',
+                '{"items":[{"$ref":"#","default":[]}], "default": "valueOne"}',
                 '[[]]'
             ),
             array(// #17 default top value does not overwrite defined null

--- a/tests/Constraints/FactoryTest.php
+++ b/tests/Constraints/FactoryTest.php
@@ -12,7 +12,7 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Constraints\Factory;
 use JsonSchema\Entity\JsonPointer;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MyBadConstraint

--- a/tests/Constraints/FormatTest.php
+++ b/tests/Constraints/FormatTest.php
@@ -77,7 +77,7 @@ class FormatTest extends BaseTestCase
         $schema->format = $format;
 
         $validator->check($string, $schema);
-        $this->assertEquals(1, count($validator->getErrors()), 'Expected 1 error');
+        $this->assertCount(1, $validator->getErrors(), 'Expected 1 error');
     }
 
     /**

--- a/tests/Constraints/LongArraysTest.php
+++ b/tests/Constraints/LongArraysTest.php
@@ -100,11 +100,4 @@ class LongArraysTest extends VeryBaseTestCase
         $validator->check($checkValue, $schema);
         $this->assertTrue($validator->isValid(), print_r($validator->getErrors(), true));
     }
-
-    private static function millis()
-    {
-        $mt = explode(' ', microtime());
-
-        return $mt[1] * 1000 + round($mt[0] * 1000);
-    }
 }

--- a/tests/Constraints/PointerTest.php
+++ b/tests/Constraints/PointerTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class PointerTest extends \PHPUnit_Framework_TestCase
+class PointerTest extends TestCase
 {
     protected $validateSchema = true;
 

--- a/tests/Constraints/SchemaValidationTest.php
+++ b/tests/Constraints/SchemaValidationTest.php
@@ -11,8 +11,9 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class SchemaValidationTest extends \PHPUnit_Framework_TestCase
+class SchemaValidationTest extends TestCase
 {
     protected $validateSchema = true;
 

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -11,6 +11,7 @@ namespace JsonSchema\Tests\Constraints;
 
 use JsonSchema\Constraints\TypeCheck\LooseTypeCheck;
 use JsonSchema\Constraints\TypeConstraint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class TypeTest
@@ -19,7 +20,7 @@ use JsonSchema\Constraints\TypeConstraint;
  *
  * @author hakre <https://github.com/hakre>
  */
-class TypeTest extends \PHPUnit_Framework_TestCase
+class TypeTest extends TestCase
 {
     /**
      * @see testIndefiniteArticleForTypeInTypeCheckErrorMessage

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -58,7 +58,7 @@ class TypeTest extends TestCase
      */
     public function testLooseTypeChecking()
     {
-        $v = new \StdClass();
+        $v = new \stdClass();
         $v->property = 'dataOne';
         LooseTypeCheck::propertySet($v, 'property', 'dataTwo');
         $this->assertEquals('dataTwo', $v->property);
@@ -111,7 +111,7 @@ class TypeTest extends TestCase
     public function testValidateTypeException()
     {
         $t = new TypeConstraint();
-        $data = new \StdClass();
+        $data = new \stdClass();
         $schema = json_decode('{"type": "notAValidTypeName"}');
 
         $this->setExpectedException(

--- a/tests/Constraints/ValidationExceptionTest.php
+++ b/tests/Constraints/ValidationExceptionTest.php
@@ -12,8 +12,9 @@ namespace JsonSchema\Tests\Constraints;
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Exception\ValidationException;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidationExceptionTest extends \PHPUnit_Framework_TestCase
+class ValidationExceptionTest extends TestCase
 {
     public function testValidationException()
     {

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -9,12 +9,13 @@
 
 namespace JsonSchema\Tests\Constraints;
 
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
 /**
  * @package JsonSchema\Tests\Constraints
  */
-abstract class VeryBaseTestCase extends \PHPUnit_Framework_TestCase
+abstract class VeryBaseTestCase extends TestCase
 {
     /** @var object */
     private $jsonSchemaDraft03;

--- a/tests/Drafts/Draft3Test.php
+++ b/tests/Drafts/Draft3Test.php
@@ -9,8 +9,6 @@
 
 namespace JsonSchema\Tests\Drafts;
 
-use JsonSchema\Constraints\Constraint;
-
 /**
  * @package JsonSchema\Tests\Drafts
  */

--- a/tests/Entity/JsonPointerTest.php
+++ b/tests/Entity/JsonPointerTest.php
@@ -10,13 +10,14 @@
 namespace JsonSchema\Tests\Entity;
 
 use JsonSchema\Entity\JsonPointer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @package JsonSchema\Tests\Entity
  *
  * @author Joost Nijhuis <jnijhuis81@gmail.com>
  */
-class JsonPointerTest extends \PHPUnit_Framework_TestCase
+class JsonPointerTest extends TestCase
 {
     /**
      * @dataProvider getTestData

--- a/tests/Exception/InvalidArgumentExceptionTest.php
+++ b/tests/Exception/InvalidArgumentExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidArgumentExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
+++ b/tests/Exception/InvalidSchemaMediaTypeExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidSchemaMediaTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidSchemaMediaTypeExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/InvalidSourceUriExceptionTest.php
+++ b/tests/Exception/InvalidSourceUriExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\InvalidSourceUriException;
+use PHPUnit\Framework\TestCase;
 
-class InvalidSourceUriExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidSourceUriExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/JsonDecodingExceptionTest.php
+++ b/tests/Exception/JsonDecodingExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\JsonDecodingException;
+use PHPUnit\Framework\TestCase;
 
-class JsonDecodingExceptionTest extends \PHPUnit_Framework_TestCase
+class JsonDecodingExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/ResourceNotFoundExceptionTest.php
+++ b/tests/Exception/ResourceNotFoundExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\ResourceNotFoundException;
+use PHPUnit\Framework\TestCase;
 
-class ResourceNotFoundExceptionTest extends \PHPUnit_Framework_TestCase
+class ResourceNotFoundExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/RuntimeExceptionTest.php
+++ b/tests/Exception/RuntimeExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\RuntimeException;
+use PHPUnit\Framework\TestCase;
 
-class RuntimeExceptionTest extends \PHPUnit_Framework_TestCase
+class RuntimeExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/UnresolvableJsonPointerExceptionTest.php
+++ b/tests/Exception/UnresolvableJsonPointerExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UnresolvableJsonPointerException;
+use PHPUnit\Framework\TestCase;
 
-class UnresolvableJsonPointerExceptionTest extends \PHPUnit_Framework_TestCase
+class UnresolvableJsonPointerExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Exception/UriResolverExceptionTest.php
+++ b/tests/Exception/UriResolverExceptionTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Exception;
 
 use JsonSchema\Exception\UriResolverException;
+use PHPUnit\Framework\TestCase;
 
-class UriResolverExceptionTest extends \PHPUnit_Framework_TestCase
+class UriResolverExceptionTest extends TestCase
 {
     public function testHierarchy()
     {

--- a/tests/Iterators/ObjectIteratorTest.php
+++ b/tests/Iterators/ObjectIteratorTest.php
@@ -10,8 +10,9 @@
 namespace JsonSchema\Tests\Iterators;
 
 use JsonSchema\Iterator\ObjectIterator;
+use PHPUnit\Framework\TestCase;
 
-class ObjectIteratorTest extends \PHPUnit_Framework_TestCase
+class ObjectIteratorTest extends TestCase
 {
     protected $testObject;
 

--- a/tests/Rfc3339Test.php
+++ b/tests/Rfc3339Test.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests;
 
 use JsonSchema\Rfc3339;
+use PHPUnit\Framework\TestCase;
 
-class Rfc3339Test extends \PHPUnit_Framework_TestCase
+class Rfc3339Test extends TestCase
 {
     /**
      * @param string         $string

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -114,7 +114,7 @@ class SchemaStorageTest extends TestCase
         $uriRetriever = $this->prophesize('JsonSchema\UriRetrieverInterface');
         $uriRetriever->retrieve($mainSchemaPath)
             ->willReturn($mainSchema)
-            ->shouldBeCalled($mainSchema);
+            ->shouldBeCalled();
 
         $schemaStorage = new SchemaStorage($uriRetriever->reveal());
         $schemaStorage->resolveRef("$mainSchemaPath#/definitions/car");

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -13,7 +13,6 @@ use JsonSchema\SchemaStorage;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 class SchemaStorageTest extends TestCase
 {

--- a/tests/SchemaStorageTest.php
+++ b/tests/SchemaStorageTest.php
@@ -12,9 +12,10 @@ namespace JsonSchema\Tests;
 use JsonSchema\SchemaStorage;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-class SchemaStorageTest extends \PHPUnit_Framework_TestCase
+class SchemaStorageTest extends TestCase
 {
     public function testResolveRef()
     {

--- a/tests/Uri/Retrievers/CurlTest.php
+++ b/tests/Uri/Retrievers/CurlTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Uri\Retrievers
 {
     use JsonSchema\Uri\Retrievers\Curl;
+    use PHPUnit\Framework\TestCase;
 
-    class CurlTest extends \PHPUnit_Framework_TestCase
+    class CurlTest extends TestCase
     {
         public function testRetrieveFile()
         {

--- a/tests/Uri/Retrievers/FileGetContentsTest.php
+++ b/tests/Uri/Retrievers/FileGetContentsTest.php
@@ -3,11 +3,12 @@
 namespace JsonSchema\Tests\Uri\Retrievers
 {
     use JsonSchema\Uri\Retrievers\FileGetContents;
+    use PHPUnit\Framework\TestCase;
 
     /**
      * @group FileGetContents
      */
-    class FileGetContentsTest extends \PHPUnit_Framework_TestCase
+    class FileGetContentsTest extends TestCase
     {
         /**
          * @expectedException \JsonSchema\Exception\ResourceNotFoundException

--- a/tests/Uri/Retrievers/PredefinedArrayTest.php
+++ b/tests/Uri/Retrievers/PredefinedArrayTest.php
@@ -3,11 +3,12 @@
 namespace JsonSchema\Tests\Uri\Retrievers;
 
 use JsonSchema\Uri\Retrievers\PredefinedArray;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group PredefinedArray
  */
-class PredefinedArrayTest extends \PHPUnit_Framework_TestCase
+class PredefinedArrayTest extends TestCase
 {
     private $retriever;
 

--- a/tests/Uri/UriResolverTest.php
+++ b/tests/Uri/UriResolverTest.php
@@ -3,8 +3,9 @@
 namespace JsonSchema\Tests\Uri;
 
 use JsonSchema\Uri\UriResolver;
+use PHPUnit\Framework\TestCase;
 
-class UriResolverTest extends \PHPUnit_Framework_TestCase
+class UriResolverTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -26,7 +26,7 @@ class UriRetrieverTest extends TestCase
         $this->validator = new Validator();
     }
 
-    private function getRetrieverMock($returnSchema, $returnMediaType = Validator::SCHEMA_MEDIA_TYPE)
+    private function getRetrieverMock($returnSchema)
     {
         $jsonSchema = json_decode($returnSchema);
 

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -12,11 +12,12 @@ namespace JsonSchema\Tests\Uri;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Uri\UriRetriever;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @group UriRetriever
  */
-class UriRetrieverTest extends \PHPUnit_Framework_TestCase
+class UriRetrieverTest extends TestCase
 {
     protected $validator;
 

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -4,8 +4,9 @@ namespace JsonSchema\Tests;
 
 use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
+use PHPUnit\Framework\TestCase;
 
-class ValidatorTest extends \PHPUnit_Framework_TestCase
+class ValidatorTest extends TestCase
 {
     public function testValidateWithAssocSchema()
     {

--- a/tests/ValidatorTest.php
+++ b/tests/ValidatorTest.php
@@ -2,7 +2,6 @@
 
 namespace JsonSchema\Tests;
 
-use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
 use PHPUnit\Framework\TestCase;
 


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/master) that can be backported to 5.2.7 without breaking backwards-compatibility.

## Backported PRs
 * #462 Typo fix
 * #465 override new phpcs rule (#465)
 * #466 Use `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`
 * #489 Remove unused parameter
 * #488 Remove unused private method
 * #479 No need to specify path to bin directory
 * #487 Use more appropriate assertions
 * #486 Remove unused argument from method call
 * #485 Case mismatch
 * #483 Consistently indent with 2 spaces
 * #481 Add PHP 7.2 to build matrix
 * #480 No need to update composer itself
 * #477 Implicitly enable no_unused_imports fixer
 * #478 Remove unused argument
 * #490 Keep rules sorted in `.php_cs.dist`
 * #494 Apply defaults in `$ref`'ed property / item definitions

## Skipped PRs
 * #390 (merge 6.0.0-dev into master) - out of scope for 5.x.x
 * #476 (Mark `check()` and `coerce()` as deprecated) - not deprecated in 5.x.x