### PR TITLE
Add support for "const"

### DIFF
--- a/src/JsonSchema/ConstraintError.php
+++ b/src/JsonSchema/ConstraintError.php
@@ -14,6 +14,7 @@ class ConstraintError extends Enum
     const DISALLOW = 'disallow';
     const DIVISIBLE_BY = 'divisibleBy';
     const ENUM = 'enum';
+    const CONSTANT = 'const';
     const EXCLUSIVE_MINIMUM = 'exclusiveMinimum';
     const EXCLUSIVE_MAXIMUM = 'exclusiveMaximum';
     const FORMAT_COLOR = 'colorFormat';
@@ -63,6 +64,7 @@ class ConstraintError extends Enum
             self::DISALLOW => 'Disallowed value was matched',
             self::DIVISIBLE_BY => 'Is not divisible by %d',
             self::ENUM => 'Does not have a value in the enumeration %s',
+            self::CONSTANT => 'Does not have a value equal to %s',
             self::EXCLUSIVE_MINIMUM => 'Must have a minimum value greater than %d',
             self::EXCLUSIVE_MAXIMUM => 'Must have a maximum value less than %d',
             self::FORMAT_COLOR => 'Invalid color',

--- a/src/JsonSchema/Constraints/ConstConstraint.php
+++ b/src/JsonSchema/Constraints/ConstConstraint.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Constraints;
+
+use JsonSchema\ConstraintError;
+use JsonSchema\Entity\JsonPointer;
+
+/**
+ * The ConstConstraint Constraints, validates an element against a constant value
+ *
+ * @author Martin Helmich <martin@helmich.me>
+ */
+class ConstConstraint extends Constraint
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function check(&$element, $schema = null, JsonPointer $path = null, $i = null)
+    {
+        // Only validate const if the attribute exists
+        if ($element instanceof UndefinedConstraint && (!isset($schema->required) || !$schema->required)) {
+            return;
+        }
+        $const = $schema->const;
+
+        $type = gettype($element);
+        $constType = gettype($const);
+
+        if ($this->factory->getConfig(self::CHECK_MODE_TYPE_CAST) && $type == 'array' && $constType == 'object') {
+            if ((object) $element == $const) {
+                return;
+            }
+        }
+
+        if ($type === gettype($const)) {
+            if ($type == 'object') {
+                if ($element == $const) {
+                    return;
+                }
+            } elseif ($element === $const) {
+                return;
+            }
+        }
+
+        $this->addError(ConstraintError::CONSTANT(), $path, array('const' => $schema->const));
+    }
+}

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -170,6 +170,22 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     }
 
     /**
+     * Checks a const element
+     *
+     * @param mixed            $value
+     * @param mixed            $schema
+     * @param JsonPointer|null $path
+     * @param mixed            $i
+     */
+    protected function checkConst($value, $schema = null, JsonPointer $path = null, $i = null)
+    {
+        $validator = $this->factory->createInstanceFor('const');
+        $validator->check($value, $schema, $path, $i);
+
+        $this->addErrors($validator->getErrors());
+    }
+
+    /**
      * Checks format of an element
      *
      * @param mixed            $value

--- a/src/JsonSchema/Constraints/Factory.php
+++ b/src/JsonSchema/Constraints/Factory.php
@@ -58,6 +58,7 @@ class Factory
         'string' => 'JsonSchema\Constraints\StringConstraint',
         'number' => 'JsonSchema\Constraints\NumberConstraint',
         'enum' => 'JsonSchema\Constraints\EnumConstraint',
+        'const' => 'JsonSchema\Constraints\ConstConstraint',
         'format' => 'JsonSchema\Constraints\FormatConstraint',
         'schema' => 'JsonSchema\Constraints\SchemaConstraint',
         'validator' => 'JsonSchema\Validator'

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -96,6 +96,11 @@ class UndefinedConstraint extends Constraint
         if (isset($schema->enum)) {
             $this->checkEnum($value, $schema, $path, $i);
         }
+
+        // check const
+        if (isset($schema->const)) {
+            $this->checkConst($value, $schema, $path, $i);
+        }
     }
 
     /**

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -165,6 +165,13 @@ class CoerciveTest extends VeryBaseTestCase
             'integer', 'boolean', true, true
         );
 
+        // #51 check boolean coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"boolean","const":false}}}',
+            '{"propertyOne":"false"}',
+            'string', 'boolean', false, true
+        );
+
         foreach ($types as $toType => $testCases) {
             foreach ($testCases as $testCase) {
                 $tests[] = array(

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -144,6 +144,27 @@ class CoerciveTest extends VeryBaseTestCase
             'string', 'integer', 42, true
         );
 
+        // #48 check boolean coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"boolean","const":false}}}',
+            '{"propertyOne":"false"}',
+            'string', 'boolean', false, true
+        );
+
+        // #49 check boolean coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"boolean","const":true}}}',
+            '{"propertyOne":"true"}',
+            'string', 'boolean', true, true
+        );
+
+        // #50 check boolean coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"boolean","const":true}}}',
+            '{"propertyOne":1}',
+            'integer', 'boolean', true, true
+        );
+
         foreach ($types as $toType => $testCases) {
             foreach ($testCases as $testCase) {
                 $tests[] = array(

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -137,7 +137,7 @@ class CoerciveTest extends VeryBaseTestCase
             'integer', 'string', "42", true
         );
 
-        // #46 check coercion with "const"
+        // #47 check coercion with "const"
         $tests[] = array(
             '{"properties":{"propertyOne":{"type":"number","const":42}}}',
             '{"propertyOne":"42"}',

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -130,7 +130,20 @@ class CoerciveTest extends VeryBaseTestCase
             'string', 'integer', 42, true
         );
 
-        $tests = array();
+        // #46 check coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"string","const":"42"}}}',
+            '{"propertyOne":42}',
+            'integer', 'string', "42", true
+        );
+
+        // #46 check coercion with "const"
+        $tests[] = array(
+            '{"properties":{"propertyOne":{"type":"number","const":42}}}',
+            '{"propertyOne":"42"}',
+            'string', 'integer', 42, true
+        );
+
         foreach ($types as $toType => $testCases) {
             foreach ($testCases as $testCase) {
                 $tests[] = array(

--- a/tests/Constraints/CoerciveTest.php
+++ b/tests/Constraints/CoerciveTest.php
@@ -134,7 +134,7 @@ class CoerciveTest extends VeryBaseTestCase
         $tests[] = array(
             '{"properties":{"propertyOne":{"type":"string","const":"42"}}}',
             '{"propertyOne":42}',
-            'integer', 'string', "42", true
+            'integer', 'string', '42', true
         );
 
         // #47 check coercion with "const"

--- a/tests/Constraints/ConstTest.php
+++ b/tests/Constraints/ConstTest.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the JsonSchema package.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace JsonSchema\Tests\Constraints;
+
+class ConstTest extends BaseTestCase
+{
+    protected $schemaSpec = 'http://json-schema.org/draft-06/schema#';
+    protected $validateSchema = true;
+
+    public function getInvalidTests()
+    {
+        return array(
+            array(
+                '{"value":"foo"}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","const":"bar"}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+            array(
+                '{"value":5}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"integer","const":6}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+            array(
+                '{"value":false}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"boolean","const":true}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+        );
+    }
+
+    public function getValidTests()
+    {
+        return array(
+            array(
+                '{"value":"bar"}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"string","const":"bar"}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+            array(
+                '{"value":false}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"boolean","const":false}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+            array(
+                '{"value":true}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"boolean","const":true}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+            array(
+                '{"value":5}',
+                '{
+                  "type":"object",
+                  "properties":{
+                    "value":{"type":"integer","const":5}
+                  },
+                  "additionalProperties":false
+                }'
+            ),
+        );
+    }
+}


### PR DESCRIPTION
As discussed in #506, this PR adds support for the `const` keyword as first specified in [section 6.24 of draft 06](https://tools.ietf.org/html/draft-wright-json-schema-validation-01#section-6.24).

Fixes #506