### PR TITLE
Add HHVM to allow_failures in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       dist: trusty
   allow_failures:
     - php: 'nightly'
+    - php: hhvm
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi


### PR DESCRIPTION
This PR adds HHVM to the `allow_failures` section of `.travis.yml` to address the recent CI job failures for that variant