### PR TITLE
Fix: Pin friendsofphp/php-cs-fixer to minor version

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,11 +11,9 @@ $config
         '@PSR2' => true,
         '@Symfony' => true,
         // additionally
-        'align_multiline_comment' => array('comment_type' => 'phpdocs_like'),
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
-        'increment_style' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,
@@ -25,7 +23,6 @@ $config
         'pre_increment' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
-        'yoda_style' => null,
     ))
     ->setFinder($finder)
 ;

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.1",
+        "friendsofphp/php-cs-fixer": "~2.2.20",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },


### PR DESCRIPTION
❗️ Blocks #491.

This PR

* [x] pins `friendsofphp/php-cs-fixer` to a compatible minor version
* [x] removes unknown fixers

Follows https://github.com/justinrainbow/json-schema/pull/491#issuecomment-430517542.