### PR TITLE
Fix min/maxProperties check for invalid array input

### DIFF
--- a/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
@@ -31,6 +31,10 @@ class StrictTypeCheck implements TypeCheckInterface
 
     public static function propertyCount($value)
     {
+        if (!is_object($value)) {
+            return 0;
+        }
+
         return count(get_object_vars($value));
     }
 }

--- a/tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/Constraints/MinMaxPropertiesTest.php
@@ -123,6 +123,16 @@ class MinMaxPropertiesTest extends BaseTestCase
                   }
                 }'
             ),
+            array(
+                '{
+                  "value": []
+                }',
+                '{
+                  "properties": {
+                    "value": {"minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
         );
     }
 }


### PR DESCRIPTION
For invalid array input validation falls with `get_object_vars() expects parameter 1 to be object, array given` error.