### PR TITLE
Backports for 5.2.8

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -11,11 +11,9 @@ $config
         '@PSR2' => true,
         '@Symfony' => true,
         // additionally
-        'align_multiline_comment' => array('comment_type' => 'phpdocs_like'),
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
-        'increment_style' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,
@@ -25,7 +23,6 @@ $config
         'pre_increment' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
-        'yoda_style' => null,
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ matrix:
       dist: trusty
   allow_failures:
     - php: 'nightly'
+    - php: hhvm
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -129,7 +129,7 @@ function parseHeaderValue($headerValue)
 /**
  * Send a string to the output stream, but only if --quiet is not enabled
  *
- * @param $str A string output
+ * @param $str string A string output
  */
 function output($str) {
     global $arOptions;

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.1",
+        "friendsofphp/php-cs-fixer": "~2.2.20",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,12 @@
 {
     "name": "justinrainbow/json-schema",
-    "description": "A library to validate a json schema.",
-    "keywords": ["json", "schema"],
-    "homepage": "https://github.com/justinrainbow/json-schema",
     "type": "library",
+    "description": "A library to validate a json schema.",
+    "keywords": [
+        "json",
+        "schema"
+    ],
+    "homepage": "https://github.com/justinrainbow/json-schema",
     "license": "MIT",
     "authors": [
         {
@@ -23,43 +26,51 @@
             "email": "seroscho@googlemail.com"
         }
     ],
-    "repositories": [{
-        "type": "package",
-        "package": {
-            "name": "json-schema/JSON-Schema-Test-Suite",
-            "version": "1.2.0",
-            "source": {
-                "url": "https://github.com/json-schema/JSON-Schema-Test-Suite",
-                "type": "git",
-                "reference": "1.2.0"
-            }
-        }
-    }],
     "require": {
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "friendsofphp/php-cs-fixer": "^2.1",
+        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },
-    "autoload": {
-        "psr-4": { "JsonSchema\\": "src/JsonSchema/" }
-    },
-    "autoload-dev": {
-        "psr-4": { "JsonSchema\\Tests\\": "tests/" }
-    },
-    "bin": ["bin/validate-json"],
     "extra": {
         "branch-alias": {
             "dev-master": "5.0.x-dev"
         }
     },
+    "autoload": {
+        "psr-4": {
+            "JsonSchema\\": "src/JsonSchema/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "JsonSchema\\Tests\\": "tests/"
+        }
+    },
+    "repositories": [
+        {
+            "type": "package",
+            "package": {
+                "name": "json-schema/JSON-Schema-Test-Suite",
+                "version": "1.2.0",
+                "source": {
+                    "type": "git",
+                    "url": "https://github.com/json-schema/JSON-Schema-Test-Suite",
+                    "reference": "1.2.0"
+                }
+            }
+        }
+    ],
+    "bin": [
+        "bin/validate-json"
+    ],
     "scripts": {
-        "test" : "phpunit",
-        "testOnly" : "phpunit --colors --filter",
-        "coverage" : "phpunit --coverage-text",
-        "style-check" : "php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix" : "php-cs-fixer fix --verbose"
+        "coverage": "phpunit --coverage-text",
+        "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
+        "style-fix": "php-cs-fixer fix --verbose",
+        "test": "phpunit",
+        "testOnly": "phpunit --colors --filter"
     }
 }

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -69,18 +69,13 @@ class NumberConstraint extends Constraint
 
     private function fmod($number1, $number2)
     {
-        $number1 = abs($number1);
         $modulus = ($number1 - round($number1 / $number2) * $number2);
-        $precision = abs(0.0000000001);
-        $diff = (float) ($modulus - $number2);
+        $precision = 0.0000000001;
 
-        if (-$precision < $diff && $diff < $precision) {
+        if (-$precision < $modulus && $modulus < $precision) {
             return 0.0;
         }
 
-        $decimals1 = mb_strpos($number1, '.') ? mb_strlen($number1) - mb_strpos($number1, '.') - 1 : 0;
-        $decimals2 = mb_strpos($number2, '.') ? mb_strlen($number2) - mb_strpos($number2, '.') - 1 : 0;
-
-        return (float) round($modulus, max($decimals1, $decimals2));
+        return $modulus;
     }
 }

--- a/src/JsonSchema/Constraints/NumberConstraint.php
+++ b/src/JsonSchema/Constraints/NumberConstraint.php
@@ -70,7 +70,7 @@ class NumberConstraint extends Constraint
     private function fmod($number1, $number2)
     {
         $number1 = abs($number1);
-        $modulus = fmod($number1, $number2);
+        $modulus = ($number1 - round($number1 / $number2) * $number2);
         $precision = abs(0.0000000001);
         $diff = (float) ($modulus - $number2);
 

--- a/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
+++ b/src/JsonSchema/Constraints/TypeCheck/StrictTypeCheck.php
@@ -31,6 +31,10 @@ class StrictTypeCheck implements TypeCheckInterface
 
     public static function propertyCount($value)
     {
+        if (!is_object($value)) {
+            return 0;
+        }
+
         return count(get_object_vars($value));
     }
 }

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -33,6 +33,14 @@ class UriRetriever implements BaseUriRetrieverInterface
     );
 
     /**
+     * @var array A blacklist for media type ceheck exclusion
+     */
+    protected $mediaTypeBlacklist = array(
+        'http://json-schema.org/',
+        'https://json-schema.org/'
+    );
+
+    /**
      * @var null|UriRetrieverInterface
      */
     protected $uriRetriever = null;
@@ -43,6 +51,16 @@ class UriRetriever implements BaseUriRetrieverInterface
      * @see loadSchema
      */
     private $schemaCache = array();
+
+    /**
+     * Adds an endpoint to the media type validation blacklist
+     *
+     * @param string $endpoint
+     */
+    public function addBlacklistedEndpoint($endpoint)
+    {
+        $this->mediaTypeBlacklist[] = $endpoint;
+    }
 
     /**
      * Guarantee the correct media type was encountered
@@ -65,9 +83,10 @@ class UriRetriever implements BaseUriRetrieverInterface
             return;
         }
 
-        if (substr($uri, 0, 23) == 'http://json-schema.org/') {
-            //HACK; they deliver broken content types
-            return true;
+        for ($i = 0, $iMax = count($this->mediaTypeBlacklist); $i < $iMax; $i++) {
+            if (stripos($uri, $this->mediaTypeBlacklist[$i]) === 0) {
+                return true;
+            }
         }
 
         throw new InvalidSchemaMediaTypeException(sprintf('Media type %s expected', Validator::SCHEMA_MEDIA_TYPE));

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -33,7 +33,7 @@ class UriRetriever implements BaseUriRetrieverInterface
     );
 
     /**
-     * @var array A blacklist for media type ceheck exclusion
+     * @var array A blacklist for media type check exclusion
      */
     protected $mediaTypeBlacklist = array(
         'http://json-schema.org/',

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -33,9 +33,9 @@ class UriRetriever implements BaseUriRetrieverInterface
     );
 
     /**
-     * @var array A blacklist for media type check exclusion
+     * @var array A list of endpoints for media type check exclusion
      */
-    protected $mediaTypeBlacklist = array(
+    protected $allowedInvalidContentTypeEndpoints = array(
         'http://json-schema.org/',
         'https://json-schema.org/'
     );
@@ -53,13 +53,13 @@ class UriRetriever implements BaseUriRetrieverInterface
     private $schemaCache = array();
 
     /**
-     * Adds an endpoint to the media type validation blacklist
+     * Adds an endpoint to the media type validation exclusion list
      *
      * @param string $endpoint
      */
-    public function addBlacklistedEndpoint($endpoint)
+    public function addInvalidContentTypeEndpoint($endpoint)
     {
-        $this->mediaTypeBlacklist[] = $endpoint;
+        $this->allowedInvalidContentTypeEndpoints[] = $endpoint;
     }
 
     /**
@@ -83,8 +83,8 @@ class UriRetriever implements BaseUriRetrieverInterface
             return;
         }
 
-        for ($i = 0, $iMax = count($this->mediaTypeBlacklist); $i < $iMax; $i++) {
-            if (stripos($uri, $this->mediaTypeBlacklist[$i]) === 0) {
+        foreach ($this->allowedInvalidContentTypeEndpoints as $endpoint) {
+            if (strpos($uri, $endpoint) === 0) {
                 return true;
             }
         }

--- a/tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/Constraints/MinMaxPropertiesTest.php
@@ -123,6 +123,16 @@ class MinMaxPropertiesTest extends BaseTestCase
                   }
                 }'
             ),
+            array(
+                '{
+                  "value": []
+                }',
+                '{
+                  "properties": {
+                    "value": {"minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
         );
     }
 }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -330,13 +330,35 @@ EOF;
         $this->assertEquals('454f423bd7edddf0bc77af4130ed9161', md5(json_encode($schema)));
     }
 
-    public function testJsonSchemaOrgMediaTypeHack()
+    public function testJsonSchemaOrgMediaTypeBlacklistDefault()
     {
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
         $this->assertTrue($retriever->confirmMediaType($mock, 'http://json-schema.org/'));
+    }
+
+    /**
+     * @expectedException \JsonSchema\Exception\InvalidSchemaMediaTypeException
+     */
+    public function testJsonSchemaOrgMediaTypeBlacklistUnknown()
+    {
+        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
+        $retriever = new UriRetriever();
+
+        $retriever->confirmMediaType($mock, 'http://iglucentral.com');
+    }
+
+    public function testJsonSchemaOrgMediaTypeBlacklistAdded()
+    {
+        $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
+        $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
+        $retriever = new UriRetriever();
+        $retriever->addBlacklistedEndpoint('http://iglucentral.com');
+
+        $retriever->confirmMediaType($mock, 'http://iglucentral.com');
     }
 
     public function testSchemaCache()

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -356,7 +356,7 @@ EOF;
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
-        $retriever->addBlacklistedEndpoint('http://example.com');
+        $retriever->addInvalidContentTypeEndpoint('http://example.com');
 
         $retriever->confirmMediaType($mock, 'http://example.com');
     }

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -330,19 +330,20 @@ EOF;
         $this->assertEquals('454f423bd7edddf0bc77af4130ed9161', md5(json_encode($schema)));
     }
 
-    public function testJsonSchemaOrgMediaTypeBlacklistDefault()
+    public function testInvalidContentTypeEndpointsDefault()
     {
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
         $this->assertTrue($retriever->confirmMediaType($mock, 'http://json-schema.org/'));
+        $this->assertTrue($retriever->confirmMediaType($mock, 'https://json-schema.org/'));
     }
 
     /**
      * @expectedException \JsonSchema\Exception\InvalidSchemaMediaTypeException
      */
-    public function testJsonSchemaOrgMediaTypeBlacklistUnknown()
+    public function testInvalidContentTypeEndpointsUnknown()
     {
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
@@ -351,7 +352,7 @@ EOF;
         $retriever->confirmMediaType($mock, 'http://example.com');
     }
 
-    public function testJsonSchemaOrgMediaTypeBlacklistAdded()
+    public function testInvalidContentTypeEndpointsAdded()
     {
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -348,7 +348,7 @@ EOF;
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
 
-        $retriever->confirmMediaType($mock, 'http://iglucentral.com');
+        $retriever->confirmMediaType($mock, 'http://example.com');
     }
 
     public function testJsonSchemaOrgMediaTypeBlacklistAdded()
@@ -356,9 +356,9 @@ EOF;
         $mock = $this->getMock('JsonSchema\Uri\UriRetriever', array('getContentType'));
         $mock->method('getContentType')->willReturn('Application/X-Fake-Type');
         $retriever = new UriRetriever();
-        $retriever->addBlacklistedEndpoint('http://iglucentral.com');
+        $retriever->addBlacklistedEndpoint('http://example.com');
 
-        $retriever->confirmMediaType($mock, 'http://iglucentral.com');
+        $retriever->confirmMediaType($mock, 'http://example.com');
     }
 
     public function testSchemaCache()


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/master) that can be backported to 5.2.8 without breaking backwards-compatibility.

## Backported PRs
 * #470 Don't use PHP's fmod
 * #498 Remove type-specific performance optimisation (#441, #547)
 * #520 Add hhvm to allow_failures
 * #528 Comment (phpdoc) fix in bin/validate-json
 * #537 Pin php-cs-fixer to minor version
 * #544 Exclude some endpoints from media type validation
 * #545 Check invalid array input to min / max properties

## Skipped PRs
 * #471 Error message change - out of scope for 5.x.x (errors were rewritten for v6)
 * #507 Add support for "const" - out of scope for 5.x.x
 * #518 Strict Enum/Const Object Checking - out of scope for 5.x.x
 * #535 Return original value (this type of string coercion doesn't exist in 5.x.x)