### PR TITLE
Meida-Type : clean media type from unused data

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/AbstractRetriever.php
+++ b/src/JsonSchema/Uri/Retrievers/AbstractRetriever.php
@@ -29,6 +29,11 @@ abstract class AbstractRetriever implements UriRetrieverInterface
      */
     public function getContentType()
     {
-        return $this->contentType;
+        if(empty($this->contentType)){
+            return $this->contentType;
+        }
+
+        // return cleaned content type
+        return preg_replace('|(?<=json)(.*)|','',$this->contentType);
     }
 }


### PR DESCRIPTION
We have case , with this media type : 
application/json; charset=utf-8
This media type is not valid for **confirmMediaType** function in **UriRetriever** class , so before we retrieve it , we need to be sure , we have media type without any extra data.