### PR TITLE
Don't run checks which assume a defined instance against undefined

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -154,7 +154,7 @@ class UndefinedConstraint extends Constraint
                     $this->addError(ConstraintError::REQUIRED(), $path, array('property' => $propertyName));
                 }
             } else {
-                // If the value is both undefined and not required, skip remaining checks
+                // if the value is both undefined and not required, skip remaining checks
                 // in this method which assume an actual, defined instance when validating.
                 if ($value instanceof self) {
                     return;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -153,6 +153,12 @@ class UndefinedConstraint extends Constraint
                     $propertyName = end($propertyPaths);
                     $this->addError(ConstraintError::REQUIRED(), $path, array('property' => $propertyName));
                 }
+            } else {
+                // If the value is both undefined and not required, skip remaining checks
+                // in this method which assume an actual, defined instance when validating.
+                if ($value instanceof self) {
+                    return;
+                }
             }
         }
 

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -31,6 +31,20 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
+            ),
+            array( // check that a missing, required property is correctly validated
+                '{"y": "foo"}',
+                '{
+                    "type": "object",
+                    "required": ["x"],
+                    "properties": {
+                        "x": {
+                            "not": {
+                                "type": "null"
+                            }
+                        }
+                    }
+                }'
             )
         );
     }
@@ -65,6 +79,19 @@ class NotTest extends BaseTestCase
                                 "type": "array",
                                 "items": {"type": "integer"},
                                 "minItems": 2
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // check that a missing, non-required property isn't validated
+                '{"y": "foo"}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "x": {
+                            "not": {
+                                "type": "null"
                             }
                         }
                     }


### PR DESCRIPTION
Adds undefined check to the end of required clause.

Validation tests for an undefined instance should be limited to those
tests which are actually applicable (e.g. required, default). Tests
which assume an instance previously attempted to validate an internal
default when the instance is undefined, rather than ignoring it, which
is incorrect behavior.

Closes #566.