### PR TITLE
Tests on php 7.3

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -23,6 +23,7 @@ $config
         'pre_increment' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
+        'yoda_style' => false,
     ))
     ->setFinder($finder)
 ;

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,9 +21,11 @@ $config
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
         'pre_increment' => false,
+        'increment_style' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
         'yoda_style' => false,
+        'phpdoc_types_order' => array('null_adjustment' => 'none', 'sort_algorithm' => 'none'),
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       env: WITH_COVERAGE=true WITH_PHPCSFIXER=true
     - php: 7.1
     - php: 7.2
+    - php: 7.3
     - php: 'nightly'
     - php: hhvm
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
-      env: WITH_COVERAGE=true WITH_PHPCSFIXER=true
+      env: WITH_COVERAGE=true
+    - php: 7.0
+      env: WITH_PHPCSFIXER=true
     - php: 7.1
     - php: 7.2
     - php: 7.3

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.15.1",
+        "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.20",
+        "friendsofphp/php-cs-fixer": "~2.15.1",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },


### PR DESCRIPTION
follows on from #563:

* adjusts php-cs-fixer config to preserve existing behaviour, rather than applying new rules added in php-cs-fixer
* splits the 7.0 run in two, so one can get feedback on php-cs-fixer before phpunit has finished running & so xdebug isn't loaded while php-cs-fixer runs.