### PR TITLE
Update the JSON Schema Test Suite to version 2.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,12 +28,13 @@
     ],
     "require": {
         "php": ">=5.3.3",
+        "ext-json": "*",
         "marc-mabe/php-enum":"^2.0 || ^3.0",
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
+        "json-schema/JSON-Schema-Test-Suite": "2.0.0",
         "phpunit/phpunit": "^4.8.35"
     },
     "extra": {
@@ -56,11 +57,11 @@
             "type": "package",
             "package": {
                 "name": "json-schema/JSON-Schema-Test-Suite",
-                "version": "1.2.0",
+                "version": "2.0.0",
                 "source": {
                     "type": "git",
                     "url": "https://github.com/json-schema/JSON-Schema-Test-Suite",
-                    "reference": "1.2.0"
+                    "reference": "2.0.0"
                 }
             }
         }

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -180,6 +180,11 @@ class ObjectConstraint extends Constraint
      */
     protected function validateMinMaxConstraint($element, $objectDefinition, JsonPointer $path = null)
     {
+        // minProperties and maxProperties constraints only applies on objects elements.
+        if (!is_object($element)) {
+            return;
+        }
+
         // Verify minimum number of properties
         if (isset($objectDefinition->minProperties) && !is_object($objectDefinition->minProperties)) {
             if ($this->getTypeCheck()->propertyCount($element) < $objectDefinition->minProperties) {

--- a/tests/Constraints/MinMaxPropertiesTest.php
+++ b/tests/Constraints/MinMaxPropertiesTest.php
@@ -63,6 +63,39 @@ class MinMaxPropertiesTest extends BaseTestCase
                   }
                 }'
             ),
+            // Ignore array.
+            array(
+                '{
+                  "value": []
+                }',
+                '{
+                  "properties": {
+                    "value": {"minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
+            // Ignore string.
+            array(
+                '{
+                  "value": "foo"
+                }',
+                '{
+                  "properties": {
+                    "value": {"minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
+            // Ignore anything that is non-object.
+            array(
+                '{
+                  "value": 42
+                }',
+                '{
+                  "properties": {
+                    "value": {"minProperties": 1,"maxProperties": 2}
+                  }
+                }'
+            ),
         );
     }
 
@@ -123,16 +156,14 @@ class MinMaxPropertiesTest extends BaseTestCase
                   }
                 }'
             ),
-            array(
-                '{
-                  "value": []
-                }',
-                '{
-                  "properties": {
-                    "value": {"minProperties": 1,"maxProperties": 2}
-                  }
-                }'
-            ),
         );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getInvalidForAssocTests()
+    {
+        return array();
     }
 }

--- a/tests/Drafts/Draft4Test.php
+++ b/tests/Drafts/Draft4Test.php
@@ -33,7 +33,10 @@ class Draft4Test extends BaseDraftTestCase
         $tests = parent::getInvalidForAssocTests();
         unset(
             $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
+            $tests['type.json / array type matches arrays / an object is not an array'],
+            // Arrays must be ignored and in assoc case, these data are arrays and not objects.
+            $tests['maxProperties.json / maxProperties validation / too long is invalid'],
+            $tests['minProperties.json / minProperties validation / too short is invalid']
         );
 
         return $tests;
@@ -44,7 +47,9 @@ class Draft4Test extends BaseDraftTestCase
         $tests = parent::getValidForAssocTests();
         unset(
             $tests['type.json / object type matches objects / an array is not an object'],
-            $tests['type.json / array type matches arrays / an object is not an array']
+            $tests['type.json / array type matches arrays / an object is not an array'],
+            // Arrays must be ignored and in assoc case, these data are arrays and not objects.
+            $tests['required.json / required validation / ignores arrays']
         );
 
         return $tests;
@@ -58,10 +63,12 @@ class Draft4Test extends BaseDraftTestCase
         return array(
             // Optional
             'bignum.json',
+            'ecmascript-regex.json',
             'format.json',
             'zeroTerminatedFloats.json',
             // Required
-            'not.json' // only one test case failing
+            'not.json', // only one test case failing
+            'ref.json', // external references can not be found (localhost:1234)
         );
     }
 }


### PR DESCRIPTION
Update the JSON Schema Test Suite to version 2.0.0 to fetch test suites on Draft 06 and Draft 07. 
Updated validation on draft 04 since changes have been done on the test suites.


Regarding some discussions on #581 I wanted to have access to the official test-suite for draft 07. This is possible by upgrading the JSON-Schema-Test-Suite in version 2.0.0, on which Draft 04 has been upgraded too.

I required to upgrade some snippet and make evolved some tests to make pass the Draft 04 validation.