### PR TITLE
Fix travis PHP 5.4 and 5.5 config.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
       env: WITH_COVERAGE=true


### PR DESCRIPTION
Travis has just changed their default distribution to xenial but this distribution doesn't support the PHP 5.4 and PHP 5.5 versions. This is why every PR is failing Travis on those versions now.

Specifying the distrib back to "trusty" so Travis can execute it, only for those 2 elder versions.