### PR TITLE
Fixed PHPDoc of Validator::validate() method

### DIFF
--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -35,8 +35,6 @@ class Validator extends BaseConstraint
      * The validation works as defined by the schema proposal in http://json-schema.org.
      *
      * Note that the first argument is passed by reference, so you must pass in a variable.
-     *
-     * {@inheritdoc}
      */
     public function validate(&$value, $schema = null, $checkMode = null)
     {


### PR DESCRIPTION
There are no BaseConstraint::validate(), so PHPDoc can not be inherited