### PR TITLE
5.x.x: Update validate-json to use spl_autoload_register

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -13,7 +13,7 @@
  *
  * @return void
  */
-function __autoload($className)
+spl_autoload_register(function ($className)
 {
     $className = ltrim($className, '\\');
     $fileName  = '';
@@ -26,7 +26,7 @@ function __autoload($className)
     if (stream_resolve_include_path($fileName)) {
         require_once $fileName;
     }
-}
+});
 
 // support running this tool from git checkout
 if (is_dir(__DIR__ . '/../src/JsonSchema')) {


### PR DESCRIPTION
Fixes #574

- `spl_autoload_register` exists since PHP 5.1, so this shouldn't be a problem backward-compatibility wise.
- There's was a more drastic change (#401 & 9fe7822) in the master to fix the same root issue, but it wasn't backported to 5.x. Hence the need for this fix.