### PR TITLE
Backports for 5.2.9

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,8 +21,11 @@ $config
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
         'pre_increment' => false,
+        'increment_style' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
+        'yoda_style' => false,
+        'phpdoc_types_order' => array('null_adjustment' => 'none', 'sort_algorithm' => 'none'),
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,12 @@ matrix:
     - php: 5.5
     - php: 5.6
     - php: 7.0
-      env: WITH_COVERAGE=true WITH_PHPCSFIXER=true
+      env: WITH_COVERAGE=true
+    - php: 7.0
+      env: WITH_PHPCSFIXER=true
     - php: 7.1
     - php: 7.2
+    - php: 7.3
     - php: 'nightly'
     - php: hhvm
       dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,9 @@ matrix:
     - php: 5.3
       dist: precise
     - php: 5.4
+      dist: trusty
     - php: 5.5
+      dist: trusty
     - php: 5.6
     - php: 7.0
       env: WITH_COVERAGE=true

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "php": ">=5.3.3"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.20",
+        "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -150,6 +150,12 @@ class UndefinedConstraint extends Constraint
                         'required'
                     );
                 }
+            } else {
+                // If the value is both undefined and not required, skip remaining checks
+                // in this method which assume an actual, defined instance when validating.
+                if ($value instanceof self) {
+                    return;
+                }
             }
         }
 

--- a/src/JsonSchema/Validator.php
+++ b/src/JsonSchema/Validator.php
@@ -34,9 +34,7 @@ class Validator extends BaseConstraint
      * Both the php object and the schema are supposed to be a result of a json_decode call.
      * The validation works as defined by the schema proposal in http://json-schema.org.
      *
-     * Note that the first argument is passwd by reference, so you must pass in a variable.
-     *
-     * {@inheritdoc}
+     * Note that the first argument is passed by reference, so you must pass in a variable.
      */
     public function validate(&$value, $schema = null, $checkMode = null)
     {

--- a/tests/Constraints/ArraysTest.php
+++ b/tests/Constraints/ArraysTest.php
@@ -71,6 +71,51 @@ class ArraysTest extends BaseTestCase
                         }
                     }
                 }'
+            ),
+            array( // Test array items.enum where type string fail validation if value(s) is/are not in items.enum
+                '{"data": ["a", "b"]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["b", "c"]
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // Test array items.enum where type integer fail validation if value(s) is/are not in items.enum
+                '{"data": [1, 2]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "enum": [2, 3]
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // Test array items.enum where type number fail validation if value(s) is/are not in items.enum
+                '{"data": [1.25, 2.25]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "number",
+                                "enum": [1.25, 2]
+                            }
+                        }
+                    }
+                }'
             )
         );
     }
@@ -165,6 +210,51 @@ class ArraysTest extends BaseTestCase
                                 {"type": "number"},
                                 {"type": "number"}
                             ]
+                        }
+                    }
+                }'
+            ),
+            array( // Test array items.enum where type string passes validation if value(s) is/are in items.enum
+                '{"data": ["c", "c", "b"]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["b", "c"]
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // Test array items.enum where type integer passes validation if value(s) is/are in items.enum
+                '{"data": [1, 1, 2]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "integer",
+                                "enum": [1, 2]
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // Test array items.enum where type number passes validation if value(s) is/are in items.enum
+                '{"data": [1.25, 1.25, 2.25]}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "data": {
+                            "type": "array",
+                            "items": {
+                                "type": "number",
+                                "enum": [1.25, 2.25]
+                            }
                         }
                     }
                 }'

--- a/tests/Constraints/NotTest.php
+++ b/tests/Constraints/NotTest.php
@@ -31,6 +31,20 @@ class NotTest extends BaseTestCase
                         }
                     }
                 }'
+            ),
+            array( // check that a missing, required property is correctly validated
+                '{"y": "foo"}',
+                '{
+                    "type": "object",
+                    "required": ["x"],
+                    "properties": {
+                        "x": {
+                            "not": {
+                                "type": "null"
+                            }
+                        }
+                    }
+                }'
             )
         );
     }
@@ -65,6 +79,19 @@ class NotTest extends BaseTestCase
                                 "type": "array",
                                 "items": {"type": "integer"},
                                 "minItems": 2
+                            }
+                        }
+                    }
+                }'
+            ),
+            array( // check that a missing, non-required property isn't validated
+                '{"y": "foo"}',
+                '{
+                    "type": "object",
+                    "properties": {
+                        "x": {
+                            "not": {
+                                "type": "null"
                             }
                         }
                     }


### PR DESCRIPTION
Bugfixes from [6.0.0](https://github.com/justinrainbow/json-schema/tree/master) that can be backported to 5.2.9 without breaking backwards-compatibility.

## Backported PRs
 * #559 ArraysTest for array items with enum validation
 * #567 Don't run checks which assume a defined instance against undefined
 * #575 Tests on PHP 7.3
 * #587 Fixed PHPDoc of Validator::validate() method
 * #583 Fix travis PHP 5.4 and 5.5 config

## Additional PRs (5.x.x only)
These PRs are only applicable to the 5.x.x branch, and have been merged individually.
 * #589 Update validate-json to use spl_autoload_register

## Skipped PRs
 * #464 marc-mabe/php-enum versions (dependency not present in 5.x.x)