### PR TITLE
Fix composer warning

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
+        "json-schema/json-schema-test-suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },
     "extra": {
@@ -55,7 +55,7 @@
         {
             "type": "package",
             "package": {
-                "name": "json-schema/JSON-Schema-Test-Suite",
+                "name": "json-schema/json-schema-test-suite",
                 "version": "1.2.0",
                 "source": {
                     "type": "git",


### PR DESCRIPTION
Small one, just hide composer warning:

```
Deprecation warning: require-dev.json-schema/JSON-Schema-Test-Suite is invalid, it should not contain uppercase characters. Please use json-schema/json-schema-test-suite instead. Make sure you fix this as Composer 2.0 will error.
```