### PR TITLE
Fix: Disable no_superfluous_phpdoc_tags fixer

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -14,6 +14,7 @@ $config
         'array_syntax' => array('syntax' => 'long'),
         'binary_operator_spaces' => false,
         'concat_space' => array('spacing' => 'one'),
+        'no_superfluous_phpdoc_tags' => false,
         'no_useless_else' => true,
         'no_useless_return' => true,
         'ordered_imports' => true,


### PR DESCRIPTION
This PR

* [x] disables the `no_superfluous_phpdoc_tags` fixer, which is implicitly enabled by using the `@Symfony` rules

Related to #598.

💁‍♂ Personally, I would not use the `@Symfony` ruleset, but instead configure fixers one by one. I do this with [`localheinz/php-cs-fixer-config`](https://github.com/localheinz/php-cs-fixer-config), which allows me to re-use a configuration for `friendsofphp/php-cs-fixer` across projects. Together with https://dependabot.com, this works excellent, by the way, in keeping projects updated with a consistent configuration.