### PR TITLE
Fix: Do not allow installation of multiple versions of friendsofphp/php-cs-fixer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /docs               export-ignore
 /tests              export-ignore
+/tools              export-ignore
 .gitattributes      export-ignore
 .gitignore          export-ignore
 .travis.yml         export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/tools/vendor
 /vendor
 /bin
 !/bin/validate-json

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -21,11 +21,8 @@ $config
         'phpdoc_order' => true,
         'phpdoc_summary' => false,
         'pre_increment' => false,
-        'increment_style' => false,
         'simplified_null_return' => false,
         'trailing_comma_in_multiline_array' => false,
-        'yoda_style' => false,
-        'phpdoc_types_order' => array('null_adjustment' => 'none', 'sort_algorithm' => 'none'),
     ))
     ->setFinder($finder)
 ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ before_install:
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist
+  - if [[ "$WITH_PHPCSFIXER" == "true" ]]; then composer install --working-dir=./tools; fi
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" ]]; then ./vendor/bin/phpunit --coverage-text; else composer test; fi
-  - if [[ "$WITH_PHPCSFIXER" == "true" ]]; then mkdir -p $HOME/.phpcsfixer && vendor/bin/php-cs-fixer fix --cache-file "$HOME/.phpcsfixer/.php_cs.cache" --dry-run --diff --verbose; fi
+  - if [[ "$WITH_PHPCSFIXER" == "true" ]]; then ./tools/vendor/bin/php-cs-fixer fix --dry-run --diff --verbose; fi

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+        "friendsofphp/php-cs-fixer": "~2.2.20",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,6 @@
         "icecave/parity": "1.0.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2.2.20",
         "json-schema/JSON-Schema-Test-Suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },
@@ -70,8 +69,15 @@
     ],
     "scripts": {
         "coverage": "phpunit --coverage-text",
-        "style-check": "php-cs-fixer fix --dry-run --verbose --diff",
-        "style-fix": "php-cs-fixer fix --verbose",
+        "install-development-tools": "composer install --working-dir=./tools",
+        "style-check": [
+            "@install-development-tools",
+            "./tools/vendor/bin/php-cs-fixer fix --dry-run --verbose --diff"
+        ],
+        "style-fix": [
+            "@install-development-tools",
+            "./tools/vendor/bin/php-cs-fixer fix --verbose"
+        ],
         "test": "phpunit",
         "testOnly": "phpunit --colors --filter"
     }

--- a/tools/composer.json
+++ b/tools/composer.json
@@ -1,0 +1,15 @@
+{
+    "require": {
+        "php": "^5.3"
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "~2.2.20"
+    },
+    "config": {
+        "platform": {
+            "php": "5.3.38"
+        },
+        "preferred-install": "dist",
+        "sort-packages": true
+    }
+}


### PR DESCRIPTION
This PR

* [x] disallows installation of multiple versions of `friendsofphp/php-cs-fixer`
* [x] removes unknown fixers from the configuration for `php-cs-fixer`
* [x] installs `friendsofphp/php-cs-fixer` using a separate `composer.json` to work around PHP version incompatibilities

