### PR TITLE
Further travis tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,14 @@ matrix:
       dist: trusty
   allow_failures:
     - php: nightly
-    - php: hhvm-3.18
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm-3.18" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" = "hhvm-3.18" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:
-  - travis_retry composer install --no-interaction --prefer-dist
+  - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then travis_retry composer install; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "nightly" ]]; then travis_retry composer install --ignore-platform-reqs; fi
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" ]]; then ./vendor/bin/phpunit --coverage-text; else composer test; fi


### PR DESCRIPTION
1. Since we've pinned HHVM to 3.18, and the tests are passing, we should probably take it out of allowed failures now.

2. Nightly was failing to install dependencies (because, quite rightly, people have marked their code as not working on PHP 8 yet). We can instruct composer to ignore PHP version requirements.

3. No interaction mode is already enabled due to travis setting an env variable that enforces it.