### PR TITLE
suppress php-7.4 warning in CollectionConstraint.php: not an array

### DIFF
--- a/src/JsonSchema/Constraints/CollectionConstraint.php
+++ b/src/JsonSchema/Constraints/CollectionConstraint.php
@@ -90,7 +90,7 @@ class CollectionConstraint extends Constraint
         } else {
             // Defined item type definitions
             foreach ($value as $k => &$v) {
-                if (array_key_exists($k, $schema->items)) {
+                if (is_array($schema->items) && array_key_exists($k, $schema->items)) {
                     $this->checkUndefined($v, $schema->items[$k], $path, $k);
                 } else {
                     // Additional items
@@ -118,7 +118,7 @@ class CollectionConstraint extends Constraint
                         * caused by accidentally using $v elsewhere */
 
             // Treat when we have more schema definitions than values, not for empty arrays
-            if (count($value) > 0) {
+            if (count($value) > 0 && is_array($schema->items)) {
                 for ($k = count($value); $k < count($schema->items); $k++) {
                     $undefinedInstance = $this->factory->createInstanceFor('undefined');
                     $this->checkUndefined($undefinedInstance, $schema->items[$k], $path, $k);


### PR DESCRIPTION
In some cases php-7.4 warns that in CollectionContraint.php (lines 93 and 122) `$schema->items` used as array, but it is actually just 'true' (boolean)
Solution: check it beforehand with 'is_array'

Note: this problem happens when I use draft-07 for schema validation: eg
`validate-json json-schema-draft-07.json json-schema-draft-07.json`