### PR TITLE
Backport PHP 8 function signature fixes to 5.x.x branch

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -59,7 +59,7 @@ class UndefinedConstraint extends Constraint
      * @param JsonPointer $path
      * @param string      $i
      */
-    public function validateTypes(&$value, $schema = null, JsonPointer $path, $i = null)
+    public function validateTypes(&$value, $schema, JsonPointer $path, $i = null)
     {
         // check array
         if ($this->getTypeCheck()->isArray($value)) {
@@ -105,7 +105,7 @@ class UndefinedConstraint extends Constraint
      * @param JsonPointer $path
      * @param string      $i
      */
-    protected function validateCommonProperties(&$value, $schema = null, JsonPointer $path, $i = '')
+    protected function validateCommonProperties(&$value, $schema, JsonPointer $path, $i = '')
     {
         // if it extends another schema, it must pass that schema as well
         if (isset($schema->extends)) {


### PR DESCRIPTION
Hi Justin,
I noticed a few deprecation notices when running some tests PHP 8 master builds, and I discovered the recently merged #619 that contains the same fix for it. It was made against the master branch. Here is a PR to backport them to 5.x.x branch, which majority of the dependents currently use. Hopefully we can have a tagged release in 5.x series too :) 

Cheers.