### PR TITLE
Backports for 5.2.10: Fixes in build process and PHP 8

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,6 @@
 /docs               export-ignore
 /tests              export-ignore
+.gitattributes      export-ignore
 .gitignore          export-ignore
 .travis.yml         export-ignore
 phpunit.dist.xml    export-ignore

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,14 +28,14 @@ matrix:
       dist: trusty
   allow_failures:
     - php: nightly
-    - php: hhvm-3.18
 
 before_install:
   - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm-3.18" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
   - if [[ "$TRAVIS_PHP_VERSION" = "hhvm-3.18" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:
-  - travis_retry composer install --no-interaction --prefer-dist
+  - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then travis_retry composer install; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "nightly" ]]; then travis_retry composer install --ignore-platform-reqs; fi
 
 script:
   - if [[ "$WITH_COVERAGE" == "true" ]]; then ./vendor/bin/phpunit --coverage-text; else composer test; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: php
 
 cache:
@@ -23,16 +22,17 @@ matrix:
     - php: 7.1
     - php: 7.2
     - php: 7.3
-    - php: 'nightly'
-    - php: hhvm
+    - php: 7.4
+    - php: nightly
+    - php: hhvm-3.18
       dist: trusty
   allow_failures:
-    - php: 'nightly'
-    - php: hhvm
+    - php: nightly
+    - php: hhvm-3.18
 
 before_install:
-  - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
-  - if [[ "$TRAVIS_PHP_VERSION" = "hhvm" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
+  - if [[ "$WITH_COVERAGE" != "true" && "$TRAVIS_PHP_VERSION" != "hhvm-3.18" && "$TRAVIS_PHP_VERSION" != "nightly" && "$TRAVIS_PHP_VERSION" != "7.1" ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ "$TRAVIS_PHP_VERSION" = "hhvm-3.18" || "$TRAVIS_PHP_VERSION" = "nightly" ]]; then sed -i '/^.*friendsofphp\/php-cs-fixer.*$/d' composer.json; fi
 
 install:
   - travis_retry composer install --no-interaction --prefer-dist

--- a/bin/validate-json
+++ b/bin/validate-json
@@ -37,7 +37,7 @@ $arOptions = array();
 $arArgs = array();
 array_shift($argv);//script itself
 foreach ($argv as $arg) {
-    if ($arg{0} == '-') {
+    if ($arg[0] == '-') {
         $arOptions[$arg] = true;
     } else {
         $arArgs[] = $arg;
@@ -95,7 +95,7 @@ function getUrlFromPath($path)
         //already an URL
         return $path;
     }
-    if ($path{0} == '/') {
+    if ($path[0] == '/') {
         //absolute path
         return 'file://' . $path;
     }
@@ -200,7 +200,7 @@ if ($pathSchema === null) {
         exit(6);
     }
 }
-if ($pathSchema{0} == '/') {
+if ($pathSchema[0] == '/') {
     $pathSchema = 'file://' . $pathSchema;
 }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
-        "json-schema/JSON-Schema-Test-Suite": "1.2.0",
+        "json-schema/json-schema-test-suite": "1.2.0",
         "phpunit/phpunit": "^4.8.35"
     },
     "extra": {
@@ -53,7 +53,7 @@
         {
             "type": "package",
             "package": {
-                "name": "json-schema/JSON-Schema-Test-Suite",
+                "name": "json-schema/json-schema-test-suite",
                 "version": "1.2.0",
                 "source": {
                     "type": "git",

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -151,7 +151,7 @@ class UndefinedConstraint extends Constraint
                     );
                 }
             } else {
-                // If the value is both undefined and not required, skip remaining checks
+                // if the value is both undefined and not required, skip remaining checks
                 // in this method which assume an actual, defined instance when validating.
                 if ($value instanceof self) {
                     return;

--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -59,7 +59,7 @@ class UndefinedConstraint extends Constraint
      * @param JsonPointer $path
      * @param string      $i
      */
-    public function validateTypes(&$value, $schema = null, JsonPointer $path, $i = null)
+    public function validateTypes(&$value, $schema, JsonPointer $path, $i = null)
     {
         // check array
         if ($this->getTypeCheck()->isArray($value)) {
@@ -105,7 +105,7 @@ class UndefinedConstraint extends Constraint
      * @param JsonPointer $path
      * @param string      $i
      */
-    protected function validateCommonProperties(&$value, $schema = null, JsonPointer $path, $i = '')
+    protected function validateCommonProperties(&$value, $schema, JsonPointer $path, $i = '')
     {
         // if it extends another schema, it must pass that schema as well
         if (isset($schema->extends)) {


### PR DESCRIPTION
Closes #626

## Backported PRs
 * #614 Use lowercase package name for test suite
 * #619 Fix PHP 8 deprecated warnings
 * #607 Repleace deprecated curved brackets [sic]
 * #605 Test on PHP 7.4 and HHVM (3.18 explicitly)
 * #606 Further travis tweaks
 * #597 Add .gitattributes to .gitattributes

Cherry-picked commits related to build process and build warnings that this library often trigger in various Composer projects. No API changes. 