### PR TITLE
Streamline validation of patternProperties Regex

### DIFF
--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -163,6 +163,6 @@ class BaseConstraint
      */
     public static function jsonPatternToPhpRegex($pattern)
     {
-        return '#' . str_replace('#', '\\#', $pattern) . '#u';
+        return '~' . str_replace('~', '\\~', $pattern) . '~u';
     }
 }

--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -153,4 +153,16 @@ class BaseConstraint
 
         return (object) json_decode($json);
     }
+
+    /**
+     * Transform a JSON pattern into a PCRE regex
+     *
+     * @param string $pattern
+     *
+     * @return string
+     */
+    public static function jsonPatternToPhpRegex($pattern)
+    {
+        return '#' . str_replace('#', '\\#', $pattern) . '#u';
+    }
 }

--- a/src/JsonSchema/Constraints/FormatConstraint.php
+++ b/src/JsonSchema/Constraints/FormatConstraint.php
@@ -197,7 +197,7 @@ class FormatConstraint extends Constraint
 
     protected function validateRegex($regex)
     {
-        return false !== @preg_match('#' . str_replace('#', '\\#', $regex) . '#u', '');
+        return false !== @preg_match(self::jsonPatternToPhpRegex($regex), '');
     }
 
     protected function validateColor($color)

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -56,7 +56,7 @@ class ObjectConstraint extends Constraint
     {
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {
-            $fullRegex = '#' . str_replace('#', '\\#', $pregex) . '#u';
+            $fullRegex = self::jsonPatternToPhpRegex($pregex);
 
             // Validate the pattern before using it to test for matches
             if (@preg_match($fullRegex, '') === false) {

--- a/src/JsonSchema/Constraints/ObjectConstraint.php
+++ b/src/JsonSchema/Constraints/ObjectConstraint.php
@@ -54,24 +54,17 @@ class ObjectConstraint extends Constraint
 
     public function validatePatternProperties($element, JsonPointer $path = null, $patternProperties)
     {
-        $try = array('/', '#', '+', '~', '%');
         $matches = array();
         foreach ($patternProperties as $pregex => $schema) {
-            $delimiter = '/';
-            // Choose delimiter. Necessary for patterns like ^/ , otherwise you get error
-            foreach ($try as $delimiter) {
-                if (strpos($pregex, $delimiter) === false) { // safe to use
-                    break;
-                }
-            }
+            $fullRegex = '#' . str_replace('#', '\\#', $pregex) . '#u';
 
             // Validate the pattern before using it to test for matches
-            if (@preg_match($delimiter . $pregex . $delimiter . 'u', '') === false) {
+            if (@preg_match($fullRegex, '') === false) {
                 $this->addError(ConstraintError::PREGEX_INVALID(), $path, array('pregex' => $pregex));
                 continue;
             }
             foreach ($element as $i => $value) {
-                if (preg_match($delimiter . $pregex . $delimiter . 'u', $i)) {
+                if (preg_match($fullRegex, $i)) {
                     $matches[] = $i;
                     $this->checkUndefined($value, $schema ?: new \stdClass(), $path, $i, in_array($i, $this->appliedDefaults));
                 }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -40,7 +40,7 @@ class StringConstraint extends Constraint
         }
 
         // Verify a regex pattern
-        if (isset($schema->pattern) && !preg_match('#' . str_replace('#', '\\#', $schema->pattern) . '#u', $element)) {
+        if (isset($schema->pattern) && !preg_match(self::jsonPatternToPhpRegex($schema->pattern), $element)) {
             $this->addError(ConstraintError::PATTERN(), $path, array(
                 'pattern' => $schema->pattern,
             ));


### PR DESCRIPTION
And always escape used delimiter in passed pattern.

Refs #650