### PR TITLE
Fixed method convertJsonPointerIntoPropertyPath in wrong class

### DIFF
--- a/src/JsonSchema/Constraints/BaseConstraint.php
+++ b/src/JsonSchema/Constraints/BaseConstraint.php
@@ -153,4 +153,21 @@ class BaseConstraint
 
         return (object) json_decode($json);
     }
+
+    /**
+     * @param JsonPointer $pointer
+     *
+     * @return string property path
+     */
+    protected function convertJsonPointerIntoPropertyPath(JsonPointer $pointer)
+    {
+        $result = array_map(
+            function ($path) {
+                return sprintf(is_numeric($path) ? '[%d]' : '.%s', $path);
+            },
+            $pointer->getPropertyPaths()
+        );
+
+        return trim(implode('', $result), '.');
+    }
 }

--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -210,21 +210,4 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
     {
         return $this->factory->getTypeCheck();
     }
-
-    /**
-     * @param JsonPointer $pointer
-     *
-     * @return string property path
-     */
-    protected function convertJsonPointerIntoPropertyPath(JsonPointer $pointer)
-    {
-        $result = array_map(
-            function ($path) {
-                return sprintf(is_numeric($path) ? '[%d]' : '.%s', $path);
-            },
-            $pointer->getPropertyPaths()
-        );
-
-        return trim(implode('', $result), '.');
-    }
 }


### PR DESCRIPTION
Fixed method convertJsonPointerIntoPropertyPath() that was not in the right class (JsonSchema\Constraints\Constraint instead of JsonSchema\Constraints\BaseConstraint).
Closes #654