### PR TITLE
Restore factory config even in case of exception

### DIFF
--- a/bin/validate-json
+++ b/bin/validate-json
@@ -202,7 +202,8 @@ try {
     }
 } catch (Exception $e) {
     output("Error loading JSON schema file\n");
-    output($urlSchema . "\n");
+    output($pathSchema . "\n");
+    output($urlData . "\n");
     output($e->getMessage() . "\n");
     exit(2);
 }


### PR DESCRIPTION
E.g.
```php
// I have some initial factory config
try {
    $validator->validate($data, $schema, Constraint::CHECK_MODE_VALIDATE_SCHEMA | Constraint::CHECK_MODE_EXCEPTIONS);
    // if we get here the factory config is identical to initial (was modified then restored)
} catch (InvalidSchemaException $e) {
    // if we get here the factory config SHOULD be identical to initial too!
}
```

Implementation notes:
- best reviewed ignoring whitespaces
- ideally I would use a `finally` but I can't because of supporting PHP 5.3/5.4