### PR TITLE
Fixed: deprecated notice with PHP 8.1

### DIFF
--- a/src/JsonSchema/Constraints/Constraint.php
+++ b/src/JsonSchema/Constraints/Constraint.php
@@ -46,7 +46,7 @@ abstract class Constraint extends BaseConstraint implements ConstraintInterface
         $path = $path->withPropertyPaths(
             array_merge(
                 $path->getPropertyPaths(),
-                array_filter(array($i), 'strlen')
+                array_filter(array($i), function ($x) { return $x !== null && strlen($x); })
             )
         );
 


### PR DESCRIPTION
As of PHP 8.1, the following notice could possibly appear:
```Deprecated: strlen(): Passing null to parameter #1 ($string) of type string is deprecated in ...```
