### PR TITLE
Fix type validation failing for "any" and false-y type wording

### DIFF
--- a/src/JsonSchema/Constraints/TypeConstraint.php
+++ b/src/JsonSchema/Constraints/TypeConstraint.php
@@ -151,7 +151,7 @@ class TypeConstraint extends Constraint
      */
     protected function validateTypeNameWording($type)
     {
-        if (!isset(self::$wording[$type])) {
+        if (!array_key_exists($type, self::$wording)) {
             throw new StandardUnexpectedValueException(
                 sprintf(
                     'No wording for %s available, expected wordings are: [%s]',

--- a/tests/Constraints/TypeTest.php
+++ b/tests/Constraints/TypeTest.php
@@ -94,7 +94,31 @@ class TypeTest extends TestCase
         $this->assertSame($expected, $actualMessage); // the same for the strictness
     }
 
-    public function testValidateTypeNameWording()
+    public function validNameWordingDataProvider()
+    {
+        $wordings = array();
+
+        foreach (array_keys(TypeConstraint::$wording) as $value) {
+            $wordings[] = array($value);
+        }
+
+        return $wordings;
+    }
+
+    /**
+     * @dataProvider validNameWordingDataProvider
+     */
+    public function testValidateTypeNameWording($nameWording)
+    {
+        $t = new TypeConstraint();
+        $r = new \ReflectionObject($t);
+        $m = $r->getMethod('validateTypeNameWording');
+        $m->setAccessible(true);
+
+        $m->invoke($t, $nameWording);
+    }
+
+    public function testInvalidateTypeNameWording()
     {
         $t = new TypeConstraint();
         $r = new \ReflectionObject($t);


### PR DESCRIPTION
Fixing a small issue that makes type validation fail when type is `any` or a false-y value, due to `isset()` returning `false` for `null` variables.