### PR TITLE
Prevents infinite recursion

### DIFF
--- a/src/JsonSchema/SchemaStorage.php
+++ b/src/JsonSchema/SchemaStorage.php
@@ -79,13 +79,21 @@ class SchemaStorage implements SchemaStorageInterface
      *
      * @param mixed  $schema
      * @param string $base
+     * @param array  $stack
      */
-    private function expandRefs(&$schema, $base = null)
+    private function expandRefs(&$schema, $base = null, array $stack = [])
     {
+        if (in_array($schema, $stack)) {
+            //Prevent infinite recursion
+            return;
+        }
+
+        $stack[] = $schema;
+        
         if (!is_object($schema)) {
             if (is_array($schema)) {
                 foreach ($schema as &$member) {
-                    $this->expandRefs($member, $base);
+                    $this->expandRefs($member, $base, $stack);
                 }
             }
 
@@ -102,7 +110,7 @@ class SchemaStorage implements SchemaStorageInterface
         }
 
         foreach ($schema as &$member) {
-            $this->expandRefs($member, $base);
+            $this->expandRefs($member, $base, $stack);
         }
     }
 


### PR DESCRIPTION
I've come across a case where it was possible to generate a recursive schema. In that instance this method goes into an infinite recursion.
I'm not 100% sure whether this is an issue with json-schema itself or with the fr3d/swagger-assertions layer that I'm using on top of it, but in any case adding an anti-infinite-recursion check here seems reasonable to me.