### PR TITLE
fix(UndefinedConstraint): add attribute `#[AllowDynamicProperties]`

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -21,6 +21,7 @@ use JsonSchema\Uri\UriResolver;
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
+#[\AllowDynamicProperties]
 class UndefinedConstraint extends Constraint
 {
     /**


### PR DESCRIPTION
This change will workaround deprecation warning while applying defaults with php8.2

[php8.2 deprecations](https://www.php.net/manual/en/migration82.deprecated.php)

example code
```php

use JsonSchema\Constraints\Constraint;
use JsonSchema\Validator;

$schema = [
    'type'                 => 'object',
    'required'             => ['prop1'],
    'additionalProperties' => false,
    'properties'           => [
        'prop1' => [
            'type'                 => 'object',
            'required'             => ['prop2'],
            'additionalProperties' => false,
            'properties'           => [
                'prop2' => [
                    'type'    => 'array',
                    'items'   => [
                        'type' => 'string',
                    ],
                    'default' => ['test'],
                ],
            ],
        ],
    ],
];

$data      = new stdClass();
$validator = new Validator();
$validator->validate(
    $data,
    $schema,
    Constraint::CHECK_MODE_APPLY_DEFAULTS
);
```

 - php 5.3-8.1 - no warning
 - php 8.2 - deprecation warning

```
PHP Deprecated:  Creation of dynamic property JsonSchema\Constraints\UndefinedConstraint::$prop2 is deprecated in ...
```

This change is safe for all php versions >=5.3.0 - [online check with 3v4l.org](https://3v4l.org/4X5dg#veol)