### PR TITLE
[Backport from v6] Add attribute `#[\AllowDynamicProperties]` to allow applying defaults without deprecation warning

### DIFF
--- a/src/JsonSchema/Constraints/UndefinedConstraint.php
+++ b/src/JsonSchema/Constraints/UndefinedConstraint.php
@@ -20,6 +20,7 @@ use JsonSchema\Uri\UriResolver;
  * @author Robert Schönthal <seroscho@googlemail.com>
  * @author Bruno Prieto Reis <bruno.p.reis@gmail.com>
  */
+#[\AllowDynamicProperties]
 class UndefinedConstraint extends Constraint
 {
     /**


### PR DESCRIPTION
Backport for #695.
