### PR TITLE
Fix PHP 8.5 $http_response_header deprecation on 5.x.x

### DIFF
--- a/src/JsonSchema/Uri/Retrievers/FileGetContents.php
+++ b/src/JsonSchema/Uri/Retrievers/FileGetContents.php
@@ -49,6 +49,11 @@ class FileGetContents extends AbstractRetriever
         }
 
         $this->messageBody = $response;
+        if (function_exists('http_get_last_response_headers')) {
+            // Use http_get_last_response_headers() for BC compatibility with PHP 8.5+
+            // where $http_response_header is deprecated.
+            $http_response_header = http_get_last_response_headers();
+        }
         if (!empty($http_response_header)) {
             // $http_response_header cannot be tested, because it's defined in the method's local scope
             // See http://php.net/manual/en/reserved.variables.httpresponseheader.php for more info.


### PR DESCRIPTION
As requested in https://github.com/jsonrainbow/json-schema/pull/841#issuecomment-3607560578