### PR TITLE
Display the additional property on error instead of the value

### DIFF
--- a/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/AdditionalPropertiesConstraint.php
@@ -66,7 +66,7 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         }
 
         foreach ($additionalProperties as $key => $additionalPropertiesValue) {
-            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $additionalPropertiesValue]);
+            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $key]);
         }
     }
 

--- a/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/AdditionalPropertiesConstraint.php
@@ -66,7 +66,7 @@ class AdditionalPropertiesConstraint implements ConstraintInterface
         }
 
         foreach ($additionalProperties as $key => $additionalPropertiesValue) {
-            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $additionalPropertiesValue]);
+            $this->addError(ConstraintError::ADDITIONAL_PROPERTIES(), $path, ['found' => $key]);
         }
     }
 

--- a/tests/Constraints/AdditionalPropertiesTest.php
+++ b/tests/Constraints/AdditionalPropertiesTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace JsonSchema\Tests\Constraints;
 
+use JsonSchema\Constraints\Constraint;
 use JsonSchema\Validator;
 
 class AdditionalPropertiesTest extends BaseTestCase
@@ -104,6 +105,60 @@ class AdditionalPropertiesTest extends BaseTestCase
                   "type": "object",
                   "additionalProperties": false
                 }'
+            ];
+        yield 'Draft 6: error message contains property name not value' => [
+                '{
+                  "knownProp": "hello",
+                  "extraProp": 42
+                }',
+                '{
+                  "$schema": "http://json-schema.org/draft-06/schema#",
+                  "type": "object",
+                  "properties": {
+                    "knownProp": {"type": "string"}
+                  },
+                  "additionalProperties": false
+                }',
+                Constraint::CHECK_MODE_STRICT,
+                [
+                    [
+                        'property'   => '',
+                        'pointer'    => '',
+                        'message'    => 'The property extraProp is not defined and the definition does not allow additional properties',
+                        'constraint' => [
+                            'name'   => 'additionalProp',
+                            'params' => ['found' => 'extraProp']
+                        ],
+                        'context' => Validator::ERROR_DOCUMENT_VALIDATION
+                    ]
+                ]
+            ];
+        yield 'Draft 7: error message contains property name not value' => [
+                '{
+                  "knownProp": "hello",
+                  "extraProp": 42
+                }',
+                '{
+                  "$schema": "http://json-schema.org/draft-07/schema#",
+                  "type": "object",
+                  "properties": {
+                    "knownProp": {"type": "string"}
+                  },
+                  "additionalProperties": false
+                }',
+                Constraint::CHECK_MODE_STRICT,
+                [
+                    [
+                        'property'   => '',
+                        'pointer'    => '',
+                        'message'    => 'The property extraProp is not defined and the definition does not allow additional properties',
+                        'constraint' => [
+                            'name'   => 'additionalProp',
+                            'params' => ['found' => 'extraProp']
+                        ],
+                        'context' => Validator::ERROR_DOCUMENT_VALIDATION
+                    ]
+                ]
             ];
     }
 

--- a/tests/Constraints/VeryBaseTestCase.php
+++ b/tests/Constraints/VeryBaseTestCase.php
@@ -43,6 +43,9 @@ abstract class VeryBaseTestCase extends TestCase
                 if (strpos($args[0], DraftIdentifiers::DRAFT_6()->withoutFragment()) === 0) {
                     return $that->getDraftSchema('json-schema-draft-06.json');
                 }
+                if (strpos($args[0], DraftIdentifiers::DRAFT_7()->withoutFragment()) === 0) {
+                    return $that->getDraftSchema('json-schema-draft-07.json');
+                }
 
                 $urlParts = parse_url($args[0]);
 


### PR DESCRIPTION
## Description

Fixes the error message for additional properties to show the property name instead of the value.

Before:
```
The property 41.53824,2.42572 is not defined and the definition does not allow additional properties
```
After:
```
The property coordinates is not defined and the definition does not allow additional properties
```

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [x] My code follows the code style of this project
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes

<!-- Add any additional information that might be helpful for reviewers -->
