### PR TITLE
fix: allow "#", "?", and "?#" as valid URI references per RFC 3986

### DIFF
--- a/src/JsonSchema/Tool/Validator/RelativeReferenceValidator.php
+++ b/src/JsonSchema/Tool/Validator/RelativeReferenceValidator.php
@@ -44,14 +44,6 @@ class RelativeReferenceValidator
             return false; // Spaces are not allowed in URIs
         }
 
-        if (preg_match('/^\?#|^#$/', $ref)) {
-            return false; // Missing path but having query and fragment
-        }
-
-        if ($ref === '#' || $ref === '?') {
-            return false; // Missing path and having only fragment or query
-        }
-
         return true;
     }
 }

--- a/tests/Tool/Validator/RelativeReferenceValidatorTest.php
+++ b/tests/Tool/Validator/RelativeReferenceValidatorTest.php
@@ -30,6 +30,7 @@ class RelativeReferenceValidatorTest extends TestCase
         yield 'Fragment only' => ['ref' => '#section'];
         yield 'Empty query (RFC 3986: path-empty + query)' => ['ref' => '?'];
         yield 'Empty query and empty fragment' => ['ref' => '?#'];
+        yield 'Empty query and fragment' => ['ref' => '?#fragment'];
         yield 'Query and fragment' => ['ref' => '?query#fragment'];
     }
 

--- a/tests/Tool/Validator/RelativeReferenceValidatorTest.php
+++ b/tests/Tool/Validator/RelativeReferenceValidatorTest.php
@@ -26,6 +26,11 @@ class RelativeReferenceValidatorTest extends TestCase
         yield 'Relative path from root' => ['ref' => '/relative/path'];
         yield 'Relative path up one level' => ['ref' => '../up-one-level'];
         yield 'Relative path from current' => ['ref' => 'foo/bar'];
+        yield 'Empty fragment (RFC 3986: path-empty + fragment)' => ['ref' => '#'];
+        yield 'Fragment only' => ['ref' => '#section'];
+        yield 'Empty query (RFC 3986: path-empty + query)' => ['ref' => '?'];
+        yield 'Empty query and empty fragment' => ['ref' => '?#'];
+        yield 'Query and fragment' => ['ref' => '?query#fragment'];
     }
 
     public function invalidRelativeReferenceDataProvider(): \Generator
@@ -33,8 +38,5 @@ class RelativeReferenceValidatorTest extends TestCase
         yield 'Absolute URI' => ['ref' => 'http://example.com'];
         yield 'Three slashes' => ['ref' => '///three/slashes'];
         yield 'Path with spaces' => ['ref' => '/path with spaces'];
-        yield 'No path having query and fragment' => ['ref' => '?#invalid'];
-        yield 'Missing path having fragment' => ['ref' => '#'];
-        yield 'Missing path having query' => ['ref' => '?'];
     }
 }


### PR DESCRIPTION
## Summary

- Removes two incorrect checks in `RelativeReferenceValidator` that rejected `#`, `?`, and `?#` as invalid relative references
- Moves these values to the valid test data provider and adds additional valid cases (`#section`, `?query#fragment`)

Per [RFC 3986 Section 4.2](https://www.rfc-editor.org/rfc/rfc3986#section-4.2), these are valid relative-references composed of `path-empty` + fragment and/or query. The grammar allows zero-length paths, queries, and fragments.

This is a real-world issue: Drupal's [Canvas](https://drupal.org/project/canvas) component builder and [Byte](https://drupal.org/project/byte) theme use `format: uri-reference` for link props in SDC (Single Directory Components), and `href="#"` is common in HTML.

Fixes #909