### PR TITLE
fix: annotate resolved schemas with dialect-aware id keyword

### DIFF
--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -185,8 +185,8 @@ class UriRetriever implements BaseUriRetrieverInterface
 
         // Detect dialect from the root schema's $schema keyword before
         // resolvePointer() may walk into a sub-schema.
-        $dialect = isset($jsonSchema->{'$schema'}) ? $jsonSchema->{'$schema'} : null;
-        $usesDollarId = !in_array($dialect, [DraftIdentifiers::DRAFT_3, DraftIdentifiers::DRAFT_4], true);
+        $dialect = isset($jsonSchema->{'$schema'}) ? rtrim($jsonSchema->{'$schema'}, '#') : null;
+        $usesDollarId = !in_array($dialect, [DraftIdentifiers::DRAFT_3()->withoutFragment(), DraftIdentifiers::DRAFT_4()->withoutFragment()], true);
 
         // Use the JSON pointer if specified
         $jsonSchema = $this->resolvePointer($jsonSchema, $resolvedUri);

--- a/src/JsonSchema/Uri/UriRetriever.php
+++ b/src/JsonSchema/Uri/UriRetriever.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 
 namespace JsonSchema\Uri;
 
+use JsonSchema\DraftIdentifiers;
 use JsonSchema\Exception\InvalidSchemaMediaTypeException;
 use JsonSchema\Exception\JsonDecodingException;
 use JsonSchema\Exception\ResourceNotFoundException;
@@ -182,11 +183,17 @@ class UriRetriever implements BaseUriRetrieverInterface
 
         $jsonSchema = $this->loadSchema($fetchUri);
 
+        // Detect dialect from the root schema's $schema keyword before
+        // resolvePointer() may walk into a sub-schema.
+        $dialect = isset($jsonSchema->{'$schema'}) ? $jsonSchema->{'$schema'} : null;
+        $usesDollarId = !in_array($dialect, [DraftIdentifiers::DRAFT_3, DraftIdentifiers::DRAFT_4], true);
+
         // Use the JSON pointer if specified
         $jsonSchema = $this->resolvePointer($jsonSchema, $resolvedUri);
 
         if ($jsonSchema instanceof \stdClass) {
-            $jsonSchema->id = $resolvedUri;
+            $idKeyword = $usesDollarId ? '$id' : 'id';
+            $jsonSchema->{$idKeyword} = $resolvedUri;
         }
 
         return $jsonSchema;

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -341,6 +341,7 @@ EOF;
         // check that the schema was loaded & processed correctly
         $this->assertEquals('object', $schema->type);
         $this->assertObjectHasAttribute('$id', $schema);
+        $this->assertEquals('package://tests/fixtures/foobar.json', $schema->{'$id'});
     }
 
     public function testRetrieveDraft04SchemaWithFragmentUsesId(): void
@@ -350,6 +351,7 @@ EOF;
 
         $this->assertObjectHasAttribute('id', $schema);
         $this->assertObjectNotHasAttribute('$id', $schema);
+        $this->assertEquals('package://tests/fixtures/draft04-schema-with-fragment.json', $schema->id);
     }
 
     public function testRetrieveDraft04SchemaWithoutFragmentUsesId(): void
@@ -359,6 +361,7 @@ EOF;
 
         $this->assertObjectHasAttribute('id', $schema);
         $this->assertObjectNotHasAttribute('$id', $schema);
+        $this->assertEquals('package://tests/fixtures/draft04-schema-without-fragment.json', $schema->id);
     }
 
     public function testRetrieveDraft07SchemaWithFragmentUsesDollarId(): void
@@ -368,6 +371,7 @@ EOF;
 
         $this->assertObjectHasAttribute('$id', $schema);
         $this->assertObjectNotHasAttribute('id', $schema);
+        $this->assertEquals('package://tests/fixtures/draft07-schema.json', $schema->{'$id'});
     }
 
     public function testRetrieveDraft07SchemaWithoutFragmentUsesDollarId(): void
@@ -377,6 +381,7 @@ EOF;
 
         $this->assertObjectHasAttribute('$id', $schema);
         $this->assertObjectNotHasAttribute('id', $schema);
+        $this->assertEquals('package://tests/fixtures/draft07-schema-without-fragment.json', $schema->{'$id'});
     }
 
     public function testRetrieveSchemaWithoutDialectDefaultsToDollarId(): void
@@ -386,6 +391,7 @@ EOF;
 
         $this->assertObjectHasAttribute('$id', $schema);
         $this->assertObjectNotHasAttribute('id', $schema);
+        $this->assertEquals('package://tests/fixtures/foobar.json', $schema->{'$id'});
     }
 
     public function testInvalidContentTypeEndpointsDefault(): void

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -343,6 +343,51 @@ EOF;
         $this->assertObjectHasAttribute('$id', $schema);
     }
 
+    public function testRetrieveDraft04SchemaWithFragmentUsesId(): void
+    {
+        $retriever = new UriRetriever();
+        $schema = $retriever->retrieve('package://tests/fixtures/draft04-schema-with-fragment.json');
+
+        $this->assertObjectHasAttribute('id', $schema);
+        $this->assertObjectNotHasAttribute('$id', $schema);
+    }
+
+    public function testRetrieveDraft04SchemaWithoutFragmentUsesId(): void
+    {
+        $retriever = new UriRetriever();
+        $schema = $retriever->retrieve('package://tests/fixtures/draft04-schema-without-fragment.json');
+
+        $this->assertObjectHasAttribute('id', $schema);
+        $this->assertObjectNotHasAttribute('$id', $schema);
+    }
+
+    public function testRetrieveDraft07SchemaWithFragmentUsesDollarId(): void
+    {
+        $retriever = new UriRetriever();
+        $schema = $retriever->retrieve('package://tests/fixtures/draft07-schema.json');
+
+        $this->assertObjectHasAttribute('$id', $schema);
+        $this->assertObjectNotHasAttribute('id', $schema);
+    }
+
+    public function testRetrieveDraft07SchemaWithoutFragmentUsesDollarId(): void
+    {
+        $retriever = new UriRetriever();
+        $schema = $retriever->retrieve('package://tests/fixtures/draft07-schema-without-fragment.json');
+
+        $this->assertObjectHasAttribute('$id', $schema);
+        $this->assertObjectNotHasAttribute('id', $schema);
+    }
+
+    public function testRetrieveSchemaWithoutDialectDefaultsToDollarId(): void
+    {
+        $retriever = new UriRetriever();
+        $schema = $retriever->retrieve('package://tests/fixtures/foobar.json');
+
+        $this->assertObjectHasAttribute('$id', $schema);
+        $this->assertObjectNotHasAttribute('id', $schema);
+    }
+
     public function testInvalidContentTypeEndpointsDefault(): void
     {
         $mock = $this->createMock(\JsonSchema\Uri\Retrievers\UriRetrieverInterface::class);

--- a/tests/Uri/UriRetrieverTest.php
+++ b/tests/Uri/UriRetrieverTest.php
@@ -339,7 +339,8 @@ EOF;
         $this->assertNotFalse($schema);
 
         // check that the schema was loaded & processed correctly
-        $this->assertEquals('454f423bd7edddf0bc77af4130ed9161', md5(json_encode($schema)));
+        $this->assertEquals('object', $schema->type);
+        $this->assertObjectHasAttribute('$id', $schema);
     }
 
     public function testInvalidContentTypeEndpointsDefault(): void

--- a/tests/fixtures/draft04-schema-with-fragment.json
+++ b/tests/fixtures/draft04-schema-with-fragment.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    }
+}

--- a/tests/fixtures/draft04-schema-without-fragment.json
+++ b/tests/fixtures/draft04-schema-without-fragment.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    }
+}

--- a/tests/fixtures/draft07-schema-without-fragment.json
+++ b/tests/fixtures/draft07-schema-without-fragment.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    }
+}

--- a/tests/fixtures/draft07-schema.json
+++ b/tests/fixtures/draft07-schema.json
@@ -1,0 +1,9 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "properties": {
+        "foo": {
+            "type": "string"
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `UriRetriever::retrieve()` now reads the root schema's `$schema` keyword to determine whether to annotate with `id` (Draft-3/4) or `$id` (Draft-6+)
- Schemas without a `$schema` keyword default to `$id`, matching the library's Draft-6 default dialect
- Updated `testRetrieveSchemaFromPackage` to assert structure instead of a brittle md5 hash

## Context

`UriRetriever::retrieve()` unconditionally stamped `$jsonSchema->id = $resolvedUri` on every resolved schema. Draft-6 [renamed `id` to `$id`](https://json-schema.org/draft-06/json-schema-release-notes#backwards-incompatible-changes), but the annotation was never updated. This leaks a Draft-4 keyword into schemas resolved under Draft-6/7, causing errors in strict validators (e.g. Ajv: `NOT SUPPORTED: keyword "id", use "$id" for schema ID`).

The dialect is detected from the root schema *before* pointer resolution, so sub-schemas inherit the correct keyword from their parent document.

Internally safe — `SchemaStorage::findSchemaIdInObject()` already reads both `id` and `$id`.

## Test plan

- [x] Full test suite passes (6928 tests, 0 failures)
- [x] Verified Draft-04 meta-schema → `id`, Draft-07 → `$id`, no `$schema` → `$id`

Fixes #911