### PR TITLE
fix: Dont use mb_detect_encoding for mb_string function calls

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -246,11 +246,6 @@ parameters:
 			path: src/JsonSchema/Constraints/StringConstraint.php
 
 		-
-			message: "#^Parameter \\#2 \\$encoding of function mb_strlen expects string, string\\|false given\\.$#"
-			count: 1
-			path: src/JsonSchema/Constraints/StringConstraint.php
-
-		-
 			message: "#^Method JsonSchema\\\\Constraints\\\\TypeCheck\\\\LooseTypeCheck\\:\\:isArray\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/JsonSchema/Constraints/TypeCheck/LooseTypeCheck.php

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MaxLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MaxLengthConstraint.php
@@ -29,7 +29,7 @@ class MaxLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length <= $schema->maxLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft06/MinLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/MinLengthConstraint.php
@@ -29,7 +29,7 @@ class MinLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length >= $schema->minLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft06/PropertiesNamesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft06/PropertiesNamesConstraint.php
@@ -47,7 +47,7 @@ class PropertiesNamesConstraint implements ConstraintInterface
 
         if (property_exists($schema->propertyNames, 'maxLength')) {
             foreach ($propertyNames as $propertyName => $_) {
-                $length = mb_strlen($propertyName);
+                $length = mb_strlen($propertyName, 'UTF-8');
                 if ($length > $schema->propertyNames->maxLength) {
                     $this->addError(ConstraintError::PROPERTY_NAMES(), $path, ['propertyNames' => $schema->propertyNames, 'violating' => 'maxLength', 'length' => $length, 'name' => $propertyName]);
                 }

--- a/src/JsonSchema/Constraints/Drafts/Draft07/MaxLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/MaxLengthConstraint.php
@@ -29,7 +29,7 @@ class MaxLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length <= $schema->maxLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft07/MinLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/MinLengthConstraint.php
@@ -29,7 +29,7 @@ class MinLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length >= $schema->minLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft07/PropertiesNamesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft07/PropertiesNamesConstraint.php
@@ -47,7 +47,7 @@ class PropertiesNamesConstraint implements ConstraintInterface
 
         if (property_exists($schema->propertyNames, 'maxLength')) {
             foreach ($propertyNames as $propertyName => $_) {
-                $length = mb_strlen($propertyName);
+                $length = mb_strlen($propertyName, 'UTF-8');
                 if ($length > $schema->propertyNames->maxLength) {
                     $this->addError(ConstraintError::PROPERTY_NAMES(), $path, ['propertyNames' => $schema->propertyNames, 'violating' => 'maxLength', 'length' => $length, 'name' => $propertyName]);
                 }

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/MaxLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/MaxLengthConstraint.php
@@ -29,7 +29,7 @@ class MaxLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length <= $schema->maxLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/MinLengthConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/MinLengthConstraint.php
@@ -29,7 +29,7 @@ class MinLengthConstraint implements ConstraintInterface
             return;
         }
 
-        $length = mb_strlen($value);
+        $length = mb_strlen($value, 'UTF-8');
         if ($length >= $schema->minLength) {
             return;
         }

--- a/src/JsonSchema/Constraints/Drafts/Draft2019/PropertiesNamesConstraint.php
+++ b/src/JsonSchema/Constraints/Drafts/Draft2019/PropertiesNamesConstraint.php
@@ -47,7 +47,7 @@ class PropertiesNamesConstraint implements ConstraintInterface
 
         if (property_exists($schema->propertyNames, 'maxLength')) {
             foreach ($propertyNames as $propertyName => $_) {
-                $length = mb_strlen($propertyName);
+                $length = mb_strlen($propertyName, 'UTF-8');
                 if ($length > $schema->propertyNames->maxLength) {
                     $this->addError(ConstraintError::PROPERTY_NAMES(), $path, ['propertyNames' => $schema->propertyNames, 'violating' => 'maxLength', 'length' => $length, 'name' => $propertyName]);
                 }

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -54,7 +54,7 @@ class StringConstraint extends Constraint
     private function strlen($string)
     {
         if (extension_loaded('mbstring')) {
-            return mb_strlen($string);
+            return mb_strlen($string, 'UTF-8');
         }
 
         // mbstring is present on all test platforms, so strlen() can be ignored for coverage

--- a/src/JsonSchema/Constraints/StringConstraint.php
+++ b/src/JsonSchema/Constraints/StringConstraint.php
@@ -54,7 +54,7 @@ class StringConstraint extends Constraint
     private function strlen($string)
     {
         if (extension_loaded('mbstring')) {
-            return mb_strlen($string, mb_detect_encoding($string));
+            return mb_strlen($string);
         }
 
         // mbstring is present on all test platforms, so strlen() can be ignored for coverage


### PR DESCRIPTION
## Description
Avoid `mb_detect_encoding` for  draft 3 and 4 validations 

## Related Issue

Fixes #923 

## Type of Change

<!-- Mark the appropriate option with an "x" -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Other (please describe):

## Checklist

<!-- Mark completed items with an "x" -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) guidelines
- [X] My code follows the code style of this project
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All new and existing tests pass
- [ ] I have updated the documentation accordingly
- [x] My changes generate no new warnings

## Additional Notes
All mb_string function calls use the default value `null` which results in the internal character encoding value being used which defaults to UTF-8 and allows for local overrides through setup.
